### PR TITLE
Update dependencies and use conduit libraries.

### DIFF
--- a/Aws/S3/Commands/DeleteObject.hs
+++ b/Aws/S3/Commands/DeleteObject.hs
@@ -24,7 +24,7 @@ data DeleteObjectResponse = DeleteObjectResponse{
 
 instance SignQuery DeleteObject where
     type Info DeleteObject = S3Info
-    signQuery DeleteObject {..} = s3SignQuery S3Query { 
+    signQuery DeleteObject {..} = s3SignQuery S3Query {
                                  s3QMethod = Delete
                                , s3QBucket = Just $ T.encodeUtf8 doBucket
                                , s3QSubresources = []
@@ -34,10 +34,10 @@ instance SignQuery DeleteObject where
                                , s3QObject = Just $ T.encodeUtf8 doObjectName
                                }
 
-instance ResponseIteratee DeleteObject DeleteObjectResponse where
+instance ResponseConsumer DeleteObject DeleteObjectResponse where
     type ResponseMetadata DeleteObjectResponse = S3Metadata
-    responseIteratee _ _ _ _ = return DeleteObjectResponse
-                
+    responseConsumer _ _ _ _ _ = return DeleteObjectResponse
+
 
 instance Transaction DeleteObject DeleteObjectResponse
 

--- a/Aws/S3/Commands/GetBucket.hs
+++ b/Aws/S3/Commands/GetBucket.hs
@@ -16,12 +16,12 @@ import           Control.Applicative
 import           Control.Arrow              (second)
 import           Data.ByteString.Char8      ({- IsString -})
 import           Data.Maybe
-import           Text.XML.Enumerator.Cursor (($/), (&|), (&//))
+import           Text.XML.Cursor            (($/), (&|), (&//))
 import qualified Data.Text                  as T
 import qualified Data.Text.Encoding         as T
 import qualified Data.Traversable
 import qualified Network.HTTP.Types         as HTTP
-import qualified Text.XML.Enumerator.Cursor as Cu
+import qualified Text.XML.Cursor            as Cu
 
 data GetBucket
     = GetBucket {
@@ -34,8 +34,8 @@ data GetBucket
     deriving (Show)
 
 getBucket :: Bucket -> GetBucket
-getBucket bucket 
-    = GetBucket { 
+getBucket bucket
+    = GetBucket {
         gbBucket    = bucket
       , gbDelimiter = Nothing
       , gbMarker    = Nothing
@@ -57,7 +57,7 @@ data GetBucketResponse
 
 instance SignQuery GetBucket where
     type Info GetBucket = S3Info
-    signQuery GetBucket {..} = s3SignQuery S3Query { 
+    signQuery GetBucket {..} = s3SignQuery S3Query {
                                  s3QMethod = Get
                                , s3QBucket = Just $ T.encodeUtf8 gbBucket
                                , s3QObject = Nothing
@@ -72,10 +72,10 @@ instance SignQuery GetBucket where
                                , s3QRequestBody = Nothing
                                }
 
-instance ResponseIteratee r GetBucketResponse where
+instance ResponseConsumer r GetBucketResponse where
     type ResponseMetadata GetBucketResponse = S3Metadata
 
-    responseIteratee _ = s3XmlResponseIteratee parse
+    responseConsumer _ = s3XmlResponseConsumer parse
         where parse cursor
                   = do name <- force "Missing Name" $ cursor $/ elContent "Name"
                        let delimiter = listToMaybe $ cursor $/ elContent "Delimiter"

--- a/Aws/S3/Commands/GetService.hs
+++ b/Aws/S3/Commands/GetService.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE TypeFamilies, MultiParamTypeClasses, FlexibleInstances, OverloadedStrings #-}
 module Aws.S3.Commands.GetService
 where
-  
+
 import           Aws.Http
 import           Aws.Response
 import           Aws.S3.Info
@@ -15,29 +15,29 @@ import           Aws.Xml
 import           Data.Maybe
 import           Data.Time.Format
 import           System.Locale
-import           Text.XML.Enumerator.Cursor (($/), ($//), (&|))
-import qualified Data.Text                  as T
-import qualified Text.XML.Enumerator.Cursor as Cu
+import           Text.XML.Cursor  (($/), ($//), (&|))
+import qualified Data.Text        as T
+import qualified Text.XML.Cursor  as Cu
 
 data GetService = GetService
 
-data GetServiceResponse 
+data GetServiceResponse
     = GetServiceResponse {
         gsrOwner :: UserInfo
       , gsrBuckets :: [BucketInfo]
       }
     deriving (Show)
 
-instance ResponseIteratee r GetServiceResponse where
+instance ResponseConsumer r GetServiceResponse where
     type ResponseMetadata GetServiceResponse = S3Metadata
 
-    responseIteratee _ = s3XmlResponseIteratee parse
+    responseConsumer _ = s3XmlResponseConsumer parse
         where
           parse el = do
             owner <- forceM "Missing Owner" $ el $/ Cu.laxElement "Owner" &| parseUserInfo
             buckets <- sequence $ el $// Cu.laxElement "Bucket" &| parseBucket
             return GetServiceResponse { gsrOwner = owner, gsrBuckets = buckets }
-          
+
           parseBucket el = do
             name <- force "Missing owner Name" $ el $/ elContent "Name"
             creationDateString <- force "Missing owner CreationDate" $ el $/ elContent "CreationDate" &| T.unpack
@@ -46,14 +46,14 @@ instance ResponseIteratee r GetServiceResponse where
 
 instance SignQuery GetService where
     type Info GetService = S3Info
-    signQuery GetService = s3SignQuery S3Query { 
+    signQuery GetService = s3SignQuery S3Query {
                                 s3QMethod = Get
                               , s3QBucket = Nothing
                               , s3QObject = Nothing
                               , s3QSubresources = []
                               , s3QQuery = []
-                              , s3QAmzHeaders = [] 
-                              , s3QRequestBody = Nothing 
+                              , s3QAmzHeaders = []
+                              , s3QRequestBody = Nothing
                               }
 
 instance Transaction GetService GetServiceResponse

--- a/Aws/S3/Commands/PutObject.hs
+++ b/Aws/S3/Commands/PutObject.hs
@@ -17,7 +17,7 @@ import           Data.Maybe
 import qualified Data.CaseInsensitive       as CI
 import qualified Data.Text                  as T
 import qualified Data.Text.Encoding         as T
-import qualified Network.HTTP.Enumerator    as HTTP
+import qualified Network.HTTP.Conduit       as HTTP
 import qualified Network.HTTP.Types         as HTTP
 
 data PutObject = PutObject {
@@ -41,7 +41,7 @@ data PutObjectResponse = PutObjectResponse{
 
 instance SignQuery PutObject where
     type Info PutObject = S3Info
-    signQuery PutObject {..} = s3SignQuery S3Query { 
+    signQuery PutObject {..} = s3SignQuery S3Query {
                                  s3QMethod = Put
                                , s3QBucket = Just $ T.encodeUtf8 poBucket
                                , s3QSubresources = []
@@ -62,14 +62,14 @@ instance SignQuery PutObject where
                                             , ("x-amz-storage-class",) <$> case poStorageClass of
                                                                              Just x -> Just $ T.encodeUtf8 $ writeStorageClass x
                                                                              Nothing -> Nothing
-                                            ] ++ map( \x -> (CI.mk . T.encodeUtf8 $ T.concat ["x-amz-meta-", fst x], T.encodeUtf8 $ snd x)) poMetadata 
+                                            ] ++ map( \x -> (CI.mk . T.encodeUtf8 $ T.concat ["x-amz-meta-", fst x], T.encodeUtf8 $ snd x)) poMetadata
                                , s3QRequestBody = Just poRequestBody
                                , s3QObject = Just $ T.encodeUtf8 poObjectName
                                }
 
-instance ResponseIteratee PutObject PutObjectResponse where
+instance ResponseConsumer PutObject PutObjectResponse where
     type ResponseMetadata PutObjectResponse = S3Metadata
-    responseIteratee _ _ _ _ = do return $ PutObjectResponse Nothing
+    responseConsumer _ _ _ _ _ = do return $ PutObjectResponse Nothing
 
 instance Transaction PutObject PutObjectResponse
 

--- a/Aws/S3/Model.hs
+++ b/Aws/S3/Model.hs
@@ -5,10 +5,10 @@ where
 import           Aws.Xml
 import           Data.Time
 import           System.Locale
-import           Text.XML.Enumerator.Cursor (($/), (&|), (>=>))
-import qualified Control.Failure            as F
-import qualified Text.XML.Enumerator.Cursor as Cu
-import qualified Data.Text                  as T
+import           Text.XML.Cursor (($/), (&|))
+import qualified Control.Failure as F
+import qualified Text.XML.Cursor as Cu
+import qualified Data.Text       as T
 
 type CanonicalUserId = T.Text
 
@@ -25,11 +25,11 @@ parseUserInfo el = do id_ <- force "Missing user ID" $ el $/ elContent "ID"
                       return UserInfo { userId = id_, userDisplayName = displayName }
 
 data CannedAcl
-    = AclPrivate 
-    | AclPublicRead 
-    | AclPublicReadWrite 
-    | AclAuthenticatedRead 
-    | AclBucketOwnerRead 
+    = AclPrivate
+    | AclPublicRead
+    | AclPublicReadWrite
+    | AclAuthenticatedRead
+    | AclBucketOwnerRead
     | AclBucketOwnerFullControl
     | AclLogDeliveryWrite
     deriving (Show)
@@ -80,7 +80,7 @@ data ObjectInfo
     deriving (Show)
 
 parseObjectInfo :: F.Failure XmlException m => Cu.Cursor -> m ObjectInfo
-parseObjectInfo el 
+parseObjectInfo el
     = do key <- force "Missing object Key" $ el $/ elContent "Key"
          let time s = case parseTime defaultTimeLocale "%Y-%m-%dT%H:%M:%S%QZ" $ T.unpack s of
                         Nothing -> F.failure $ XmlException "Invalid time"

--- a/Aws/S3/Query.hs
+++ b/Aws/S3/Query.hs
@@ -19,7 +19,7 @@ import qualified Blaze.ByteString.Builder.Char8 as Blaze8
 import qualified Data.ByteString                as B
 import qualified Data.ByteString.Char8          as B8
 import qualified Data.CaseInsensitive           as CI
-import qualified Network.HTTP.Enumerator        as HTTPE
+import qualified Network.HTTP.Conduit           as HTTP
 import qualified Network.HTTP.Types             as HTTP
 
 data S3Query
@@ -30,16 +30,16 @@ data S3Query
       , s3QSubresources :: HTTP.Query
       , s3QQuery :: HTTP.Query
       , s3QAmzHeaders :: HTTP.RequestHeaders
-      , s3QRequestBody :: Maybe (HTTPE.RequestBody IO)
+      , s3QRequestBody :: Maybe (HTTP.RequestBody IO)
       }
 
 instance Show S3Query where
     show S3Query{..} = "S3Query [" ++
                        " method: " ++ show s3QMethod ++
-                       " ; bucket: " ++ show s3QBucket ++ 
-                       " ; subresources: " ++ show s3QSubresources ++ 
+                       " ; bucket: " ++ show s3QBucket ++
+                       " ; subresources: " ++ show s3QSubresources ++
                        " ; query: " ++ show s3QQuery ++
-                       " ; request body: " ++ (case s3QRequestBody of Nothing -> "no"; _ -> "yes") ++ 
+                       " ; request body: " ++ (case s3QRequestBody of Nothing -> "no"; _ -> "yes") ++
                        "]"
 
 s3SignQuery :: S3Query -> S3Info -> SignatureData -> SignedQuery
@@ -67,8 +67,8 @@ s3SignQuery S3Query{..} S3Info{..} SignatureData{..}
                                                    then (k1, B8.intercalate "," [v1, v2]):merge xs
                                                    else x1:x2:merge xs
                 merge xs = xs
-      
-      (host, path) = case s3RequestStyle of 
+
+      (host, path) = case s3RequestStyle of
                        PathStyle   -> ([Just s3Endpoint], [Just "/", fmap (`B8.snoc` '/') s3QBucket, s3QObject])
                        BucketStyle -> ([s3QBucket, Just s3Endpoint], [Just "/", s3QObject])
                        VHostStyle  -> ([Just $ fromMaybe s3Endpoint s3QBucket], [Just "/", s3QObject])

--- a/Aws/SimpleDb/Commands/BatchDeleteAttributes.hs
+++ b/Aws/SimpleDb/Commands/BatchDeleteAttributes.hs
@@ -36,8 +36,8 @@ instance SignQuery BatchDeleteAttributes where
             , ("DomainName", T.encodeUtf8 bdaDomainName)] ++
             queryList (itemQuery $ queryList (attributeQuery deleteAttributeQuery) "Attribute") "Item" bdaItems
 
-instance ResponseIteratee r BatchDeleteAttributesResponse where
+instance ResponseConsumer r BatchDeleteAttributesResponse where
     type ResponseMetadata BatchDeleteAttributesResponse = SdbMetadata
-    responseIteratee _ = sdbResponseIteratee $ sdbCheckResponseType BatchDeleteAttributesResponse "BatchDeleteAttributesResponse"
+    responseConsumer _ = sdbResponseConsumer $ sdbCheckResponseType BatchDeleteAttributesResponse "BatchDeleteAttributesResponse"
 
 instance Transaction BatchDeleteAttributes BatchDeleteAttributesResponse

--- a/Aws/SimpleDb/Commands/BatchPutAttributes.hs
+++ b/Aws/SimpleDb/Commands/BatchPutAttributes.hs
@@ -36,8 +36,8 @@ instance SignQuery BatchPutAttributes where
             , ("DomainName", T.encodeUtf8 bpaDomainName)] ++
             queryList (itemQuery $ queryList (attributeQuery setAttributeQuery) "Attribute") "Item" bpaItems
 
-instance ResponseIteratee r BatchPutAttributesResponse where
+instance ResponseConsumer r BatchPutAttributesResponse where
     type ResponseMetadata BatchPutAttributesResponse = SdbMetadata
-    responseIteratee _ = sdbResponseIteratee $ sdbCheckResponseType BatchPutAttributesResponse "BatchPutAttributesResponse"
+    responseConsumer _ = sdbResponseConsumer $ sdbCheckResponseType BatchPutAttributesResponse "BatchPutAttributesResponse"
 
 instance Transaction BatchPutAttributes BatchPutAttributesResponse

--- a/Aws/SimpleDb/Commands/CreateDomain.hs
+++ b/Aws/SimpleDb/Commands/CreateDomain.hs
@@ -29,8 +29,8 @@ instance SignQuery CreateDomain where
     type Info CreateDomain = SdbInfo
     signQuery CreateDomain{..} = sdbSignQuery [("Action", "CreateDomain"), ("DomainName", T.encodeUtf8 cdDomainName)]
 
-instance ResponseIteratee r CreateDomainResponse where
+instance ResponseConsumer r CreateDomainResponse where
     type ResponseMetadata CreateDomainResponse = SdbMetadata
-    responseIteratee _ = sdbResponseIteratee $ sdbCheckResponseType CreateDomainResponse "CreateDomainResponse"
+    responseConsumer _ = sdbResponseConsumer $ sdbCheckResponseType CreateDomainResponse "CreateDomainResponse"
 
 instance Transaction CreateDomain CreateDomainResponse

--- a/Aws/SimpleDb/Commands/DeleteAttributes.hs
+++ b/Aws/SimpleDb/Commands/DeleteAttributes.hs
@@ -43,8 +43,8 @@ instance SignQuery DeleteAttributes where
             queryList (attributeQuery deleteAttributeQuery) "Attribute" daAttributes ++
             queryList (attributeQuery expectedAttributeQuery) "Expected" daExpected
 
-instance ResponseIteratee r DeleteAttributesResponse where
+instance ResponseConsumer r DeleteAttributesResponse where
     type ResponseMetadata DeleteAttributesResponse = SdbMetadata
-    responseIteratee _ = sdbResponseIteratee $ sdbCheckResponseType DeleteAttributesResponse "DeleteAttributesResponse"
+    responseConsumer _ = sdbResponseConsumer $ sdbCheckResponseType DeleteAttributesResponse "DeleteAttributesResponse"
 
 instance Transaction DeleteAttributes DeleteAttributesResponse

--- a/Aws/SimpleDb/Commands/DeleteDomain.hs
+++ b/Aws/SimpleDb/Commands/DeleteDomain.hs
@@ -29,8 +29,8 @@ instance SignQuery DeleteDomain where
     type Info DeleteDomain = SdbInfo
     signQuery DeleteDomain{..} = sdbSignQuery [("Action", "DeleteDomain"), ("DomainName", T.encodeUtf8 ddDomainName)]
 
-instance ResponseIteratee r DeleteDomainResponse where
+instance ResponseConsumer r DeleteDomainResponse where
     type ResponseMetadata DeleteDomainResponse = SdbMetadata
-    responseIteratee _ = sdbResponseIteratee $ sdbCheckResponseType DeleteDomainResponse "DeleteDomainResponse"
+    responseConsumer _ = sdbResponseConsumer $ sdbCheckResponseType DeleteDomainResponse "DeleteDomainResponse"
 
 instance Transaction DeleteDomain DeleteDomainResponse

--- a/Aws/SimpleDb/Commands/DomainMetadata.hs
+++ b/Aws/SimpleDb/Commands/DomainMetadata.hs
@@ -12,7 +12,7 @@ import           Aws.Transaction
 import           Aws.Xml
 import           Data.Time
 import           Data.Time.Clock.POSIX
-import           Text.XML.Enumerator.Cursor (($//), (&|))
+import           Text.XML.Cursor            (($//), (&|))
 import qualified Data.Text                  as T
 import qualified Data.Text.Encoding         as T
 
@@ -33,7 +33,7 @@ data DomainMetadataResponse
       , dmrAttributeNamesSizeBytes :: Integer
       }
     deriving (Show)
-             
+
 domainMetadata :: T.Text -> DomainMetadata
 domainMetadata name = DomainMetadata { dmDomainName = name }
 
@@ -41,10 +41,10 @@ instance SignQuery DomainMetadata where
     type Info DomainMetadata = SdbInfo
     signQuery DomainMetadata{..} = sdbSignQuery [("Action", "DomainMetadata"), ("DomainName", T.encodeUtf8 dmDomainName)]
 
-instance ResponseIteratee r DomainMetadataResponse where
+instance ResponseConsumer r DomainMetadataResponse where
     type ResponseMetadata DomainMetadataResponse = SdbMetadata
 
-    responseIteratee _ = sdbResponseIteratee parse
+    responseConsumer _ = sdbResponseConsumer parse
         where parse cursor = do
                 sdbCheckResponseType () "DomainMetadataResponse" cursor
                 dmrTimestamp <- forceM "Timestamp expected" $ cursor $// elCont "Timestamp" &| (fmap posixSecondsToUTCTime . readInt)

--- a/Aws/SimpleDb/Commands/GetAttributes.hs
+++ b/Aws/SimpleDb/Commands/GetAttributes.hs
@@ -14,10 +14,10 @@ import           Aws.Util
 import           Control.Applicative
 import           Control.Monad
 import           Data.Maybe
-import           Text.XML.Enumerator.Cursor (($//), (&|))
+import           Text.XML.Cursor            (($//), (&|))
 import qualified Data.Text                  as T
 import qualified Data.Text.Encoding         as T
-import qualified Text.XML.Enumerator.Cursor as Cu
+import qualified Text.XML.Cursor            as Cu
 
 data GetAttributes
     = GetAttributes {
@@ -33,7 +33,7 @@ data GetAttributesResponse
         garAttributes :: [Attribute T.Text]
       }
     deriving (Show)
-             
+
 getAttributes :: T.Text -> T.Text -> GetAttributes
 getAttributes item domain = GetAttributes { gaItemName = item, gaAttributeName = Nothing, gaConsistentRead = False, gaDomainName = domain }
 
@@ -45,9 +45,9 @@ instance SignQuery GetAttributes where
             maybeToList (("AttributeName",) <$> T.encodeUtf8 <$> gaAttributeName) ++
             (guard gaConsistentRead >> [("ConsistentRead", awsTrue)])
 
-instance ResponseIteratee r GetAttributesResponse where
+instance ResponseConsumer r GetAttributesResponse where
     type ResponseMetadata GetAttributesResponse = SdbMetadata
-    responseIteratee _ = sdbResponseIteratee parse
+    responseConsumer _ = sdbResponseConsumer parse
         where parse cursor = do
                 sdbCheckResponseType () "GetAttributesResponse" cursor
                 attributes <- sequence $ cursor $// Cu.laxElement "Attribute" &| readAttribute

--- a/Aws/SimpleDb/Commands/ListDomains.hs
+++ b/Aws/SimpleDb/Commands/ListDomains.hs
@@ -12,7 +12,7 @@ import           Aws.Transaction
 import           Aws.Xml
 import           Control.Applicative
 import           Data.Maybe
-import           Text.XML.Enumerator.Cursor (($//))
+import           Text.XML.Cursor            (($//))
 import qualified Data.Text                  as T
 import qualified Data.Text.Encoding         as T
 
@@ -23,7 +23,7 @@ data ListDomains
       }
     deriving (Show)
 
-data ListDomainsResponse 
+data ListDomainsResponse
     = ListDomainsResponse {
         ldrDomainNames :: [T.Text]
       , ldrNextToken :: Maybe T.Text
@@ -32,7 +32,7 @@ data ListDomainsResponse
 
 listDomains :: ListDomains
 listDomains = ListDomains { ldMaxNumberOfDomains = Nothing, ldNextToken = Nothing }
-             
+
 instance SignQuery ListDomains where
     type Info ListDomains = SdbInfo
     signQuery ListDomains{..} = sdbSignQuery $ catMaybes [
@@ -41,9 +41,9 @@ instance SignQuery ListDomains where
                                 , ("NextToken",) . T.encodeUtf8 <$> ldNextToken
                                 ]
 
-instance ResponseIteratee r ListDomainsResponse where
+instance ResponseConsumer r ListDomainsResponse where
     type ResponseMetadata ListDomainsResponse = SdbMetadata
-    responseIteratee _ = sdbResponseIteratee parse 
+    responseConsumer _ = sdbResponseConsumer parse
         where parse cursor = do
                 sdbCheckResponseType () "ListDomainsResponse" cursor
                 let names = cursor $// elContent "DomainName"

--- a/Aws/SimpleDb/Commands/PutAttributes.hs
+++ b/Aws/SimpleDb/Commands/PutAttributes.hs
@@ -43,8 +43,8 @@ instance SignQuery PutAttributes where
             queryList (attributeQuery setAttributeQuery) "Attribute" paAttributes ++
             queryList (attributeQuery expectedAttributeQuery) "Expected" paExpected
 
-instance ResponseIteratee r PutAttributesResponse where
+instance ResponseConsumer r PutAttributesResponse where
     type ResponseMetadata PutAttributesResponse = SdbMetadata
-    responseIteratee _ = sdbResponseIteratee $ sdbCheckResponseType PutAttributesResponse "PutAttributesResponse"
+    responseConsumer _ = sdbResponseConsumer $ sdbCheckResponseType PutAttributesResponse "PutAttributesResponse"
 
 instance Transaction PutAttributes PutAttributesResponse

--- a/Aws/SimpleDb/Commands/Select.hs
+++ b/Aws/SimpleDb/Commands/Select.hs
@@ -15,10 +15,10 @@ import           Aws.Xml
 import           Control.Applicative
 import           Control.Monad
 import           Data.Maybe
-import           Text.XML.Enumerator.Cursor (($//), (&|))
+import           Text.XML.Cursor            (($//), (&|))
 import qualified Data.Text                  as T
 import qualified Data.Text.Encoding         as T
-import qualified Text.XML.Enumerator.Cursor as Cu
+import qualified Text.XML.Cursor            as Cu
 
 data Select
     = Select {
@@ -48,9 +48,9 @@ instance SignQuery Select where
             , (("NextToken",) . T.encodeUtf8) <$> sNextToken
             ]
 
-instance ResponseIteratee r SelectResponse where
+instance ResponseConsumer r SelectResponse where
     type ResponseMetadata SelectResponse = SdbMetadata
-    responseIteratee _ = sdbResponseIteratee parse
+    responseConsumer _ = sdbResponseConsumer parse
         where parse cursor = do
                 sdbCheckResponseType () "SelectResponse" cursor
                 items <- sequence $ cursor $// Cu.laxElement "Item" &| readItem

--- a/Aws/SimpleDb/Model.hs
+++ b/Aws/SimpleDb/Model.hs
@@ -1,17 +1,17 @@
 {-# LANGUAGE OverloadedStrings, FlexibleContexts #-}
 module Aws.SimpleDb.Model
 where
-  
+
 import           Aws.SimpleDb.Response
 import           Aws.Util
 import           Aws.Xml
 import           Control.Monad
-import           Text.XML.Enumerator.Cursor (($/), (&|))
+import           Text.XML.Cursor            (($/), (&|))
 import qualified Control.Failure            as F
 import qualified Data.ByteString            as B
 import qualified Data.Text                  as T
 import qualified Data.Text.Encoding         as T
-import qualified Text.XML.Enumerator.Cursor as Cu
+import qualified Text.XML.Cursor            as Cu
 
 data Attribute a
     = ForAttribute { attributeName :: T.Text, attributeData :: a }
@@ -22,20 +22,20 @@ readAttribute cursor = do
   name <- forceM "Missing Name" $ cursor $/ Cu.laxElement "Name" &| decodeBase64
   value <- forceM "Missing Value" $ cursor $/ Cu.laxElement "Value" &| decodeBase64
   return $ ForAttribute name value
-             
+
 data SetAttribute
     = SetAttribute { setAttribute :: T.Text, isReplaceAttribute :: Bool }
     deriving (Show)
 
 attributeQuery :: (a -> [(B.ByteString, B.ByteString)]) -> Attribute a -> [(B.ByteString, B.ByteString)]
 attributeQuery  f (ForAttribute name x) =  ("Name", T.encodeUtf8 name) : f x
-             
+
 addAttribute :: T.Text -> T.Text -> Attribute SetAttribute
 addAttribute name value = ForAttribute name (SetAttribute value False)
 
 replaceAttribute :: T.Text -> T.Text -> Attribute SetAttribute
 replaceAttribute name value = ForAttribute name (SetAttribute value True)
-             
+
 setAttributeQuery :: SetAttribute -> [(B.ByteString, B.ByteString)]
 setAttributeQuery (SetAttribute value replace)
     = ("Value", T.encodeUtf8 value) : [("Replace", awsTrue) | replace]
@@ -48,18 +48,18 @@ data DeleteAttribute
 deleteAttributeQuery :: DeleteAttribute -> [(B.ByteString, B.ByteString)]
 deleteAttributeQuery DeleteAttribute = []
 deleteAttributeQuery (ValuedDeleteAttribute value) = [("Value", T.encodeUtf8 value)]
-             
+
 data ExpectedAttribute
     = ExpectedValue { expectedAttributeValue :: T.Text }
     | ExpectedExists { expectedAttributeExists :: Bool }
     deriving (Show)
-             
+
 expectedValue :: T.Text -> T.Text -> Attribute ExpectedAttribute
 expectedValue name value = ForAttribute name (ExpectedValue value)
 
 expectedExists :: T.Text -> Bool -> Attribute ExpectedAttribute
 expectedExists name exists = ForAttribute name (ExpectedExists exists)
-             
+
 expectedAttributeQuery :: ExpectedAttribute -> [(B.ByteString, B.ByteString)]
 expectedAttributeQuery (ExpectedValue value) = [("Value", T.encodeUtf8 value)]
 expectedAttributeQuery (ExpectedExists exists) = [("Exists", awsBool exists)]
@@ -73,6 +73,6 @@ readItem cursor = do
   name <- force "Missing Name" <=< sequence $ cursor $/ Cu.laxElement "Name" &| decodeBase64
   attributes <- sequence $ cursor $/ Cu.laxElement "Attribute" &| readAttribute
   return $ Item name attributes
-             
+
 itemQuery :: (a -> [(B.ByteString, B.ByteString)]) -> Item a -> [(B.ByteString, B.ByteString)]
 itemQuery f (Item name x) = ("ItemName", T.encodeUtf8 name) : f x

--- a/Aws/SimpleDb/Response.hs
+++ b/Aws/SimpleDb/Response.hs
@@ -8,21 +8,19 @@ import           Aws.SimpleDb.Metadata
 import           Aws.Xml
 import           Data.IORef
 import           Data.Maybe
-import           Text.XML.Enumerator.Cursor (($|), ($/), ($//), (&|))
+import           Text.XML.Cursor            (($|), ($/), ($//), (&|))
 import qualified Control.Failure            as F
-import qualified Data.ByteString            as B
 import qualified Data.ByteString.Base64     as Base64
-import qualified Data.Enumerator            as En
 import qualified Data.Text                  as T
 import qualified Data.Text.Encoding         as T
-import qualified Network.HTTP.Types         as HTTP
-import qualified Text.XML.Enumerator.Cursor as Cu
+import qualified Network.HTTP.Conduit       as HTTP
+import qualified Text.XML.Cursor            as Cu
 
-sdbResponseIteratee :: 
-    (Cu.Cursor -> Response SdbMetadata a) 
-    -> IORef SdbMetadata
-    -> HTTP.Status -> HTTP.ResponseHeaders -> En.Iteratee B.ByteString IO a
-sdbResponseIteratee inner metadataRef status headers = xmlCursorIteratee parse metadataRef status headers
+sdbResponseConsumer :: (Cu.Cursor -> Response SdbMetadata a)
+                    -> IORef SdbMetadata
+                    -> HTTP.ResponseConsumer IO a
+sdbResponseConsumer inner metadataRef status headers source
+    = xmlCursorConsumer parse metadataRef status headers source
     where parse cursor
               = do let requestId' = listToMaybe $ cursor $// elContent "RequestID"
                    let boxUsage' = listToMaybe $ cursor $// elContent "BoxUsage"

--- a/Aws/Sqs/Commands/AddPermission.hs
+++ b/Aws/Sqs/Commands/AddPermission.hs
@@ -30,9 +30,9 @@ formatPermissions perms =
   concat $ zipWith(\ x y -> [(B.pack $ "AwsAccountId." ++ show y, Just $ B.pack $ T.unpack $ fst x), 
                              (B.pack $ "ActionName." ++ show y, Just $ B.pack $ T.unpack $ printPermission $ snd x)]) perms [1 :: Integer ..]
 
-instance ResponseIteratee r AddPermissionResponse where
+instance ResponseConsumer r AddPermissionResponse where
     type ResponseMetadata AddPermissionResponse = SqsMetadata
-    responseIteratee _ = sqsXmlResponseIteratee parse
+    responseConsumer _ = sqsXmlResponseConsumer parse
        where
          parse _ = do
            return AddPermissionResponse {}

--- a/Aws/Sqs/Commands/ChangeMessageVisibility.hs
+++ b/Aws/Sqs/Commands/ChangeMessageVisibility.hs
@@ -22,9 +22,9 @@ data ChangeMessageVisibility = ChangeMessageVisibility {
 data ChangeMessageVisibilityResponse = ChangeMessageVisibilityResponse{
 } deriving (Show)
 
-instance ResponseIteratee r ChangeMessageVisibilityResponse where
+instance ResponseConsumer r ChangeMessageVisibilityResponse where
     type ResponseMetadata ChangeMessageVisibilityResponse = SqsMetadata
-    responseIteratee _ = sqsXmlResponseIteratee parse
+    responseConsumer _ = sqsXmlResponseConsumer parse
       where 
         parse _ = do return ChangeMessageVisibilityResponse{}
     

--- a/Aws/Sqs/Commands/CreateQueue.hs
+++ b/Aws/Sqs/Commands/CreateQueue.hs
@@ -12,10 +12,10 @@ import           Aws.Transaction
 import           Aws.Xml
 import           Control.Applicative
 import           Data.Maybe
-import           Text.XML.Enumerator.Cursor   (($//), (&/))
+import           Text.XML.Cursor              (($//), (&/))
 import qualified Data.Text                    as T
 import qualified Data.Text.Encoding           as TE
-import qualified Text.XML.Enumerator.Cursor   as Cu
+import qualified Text.XML.Cursor              as Cu
 import qualified Data.ByteString.Char8        as B
 
 data CreateQueue = CreateQueue{
@@ -28,20 +28,20 @@ data CreateQueueResponse = CreateQueueResponse{
 } deriving (Show)
 
 
-instance ResponseIteratee r CreateQueueResponse where
+instance ResponseConsumer r CreateQueueResponse where
     type ResponseMetadata CreateQueueResponse = SqsMetadata
-    responseIteratee _ = sqsXmlResponseIteratee parse
-      where 
-        parse el = do 
+    responseConsumer _ = sqsXmlResponseConsumer parse
+      where
+        parse el = do
           url <- force "Missing Queue Url" $ el $// Cu.laxElement "QueueUrl" &/ Cu.content
           return CreateQueueResponse{ cqrQueueUrl = url}
-          
-instance SignQuery CreateQueue  where 
+
+instance SignQuery CreateQueue  where
     type Info CreateQueue  = SqsInfo
     signQuery CreateQueue {..} = sqsSignQuery SqsQuery {
-                                             sqsQueueName = Nothing,  
-                                             sqsQuery = [("Action", Just "CreateQueue"), 
-                                                        ("QueueName", Just $ TE.encodeUtf8 cqQueueName)] ++ 
+                                             sqsQueueName = Nothing,
+                                             sqsQuery = [("Action", Just "CreateQueue"),
+                                                        ("QueueName", Just $ TE.encodeUtf8 cqQueueName)] ++
                                                         catMaybes [("DefaultVisibilityTimeout",) <$> case cqDefaultVisibilityTimeout of
                                                                                                        Just x -> Just $ Just $ B.pack $ show x
                                                                                                        Nothing -> Nothing]}

--- a/Aws/Sqs/Commands/DeleteMessage.hs
+++ b/Aws/Sqs/Commands/DeleteMessage.hs
@@ -20,9 +20,9 @@ data DeleteMessage = DeleteMessage{
 data DeleteMessageResponse = DeleteMessageResponse{
 } deriving (Show)
 
-instance ResponseIteratee r DeleteMessageResponse where
+instance ResponseConsumer r DeleteMessageResponse where
     type ResponseMetadata DeleteMessageResponse = SqsMetadata
-    responseIteratee _ = sqsXmlResponseIteratee parse
+    responseConsumer _ = sqsXmlResponseConsumer parse
       where
         parse _ = do return DeleteMessageResponse {}
           

--- a/Aws/Sqs/Commands/DeleteQueue.hs
+++ b/Aws/Sqs/Commands/DeleteQueue.hs
@@ -18,9 +18,9 @@ data DeleteQueue = DeleteQueue{
 data DeleteQueueResponse = DeleteQueueResponse{
 } deriving (Show)
 
-instance ResponseIteratee r DeleteQueueResponse where
+instance ResponseConsumer r DeleteQueueResponse where
     type ResponseMetadata DeleteQueueResponse = SqsMetadata
-    responseIteratee _ = sqsXmlResponseIteratee parse
+    responseConsumer _ = sqsXmlResponseConsumer parse
       where
         parse _ = do return DeleteQueueResponse{}
           

--- a/Aws/Sqs/Commands/ListQueues.hs
+++ b/Aws/Sqs/Commands/ListQueues.hs
@@ -11,10 +11,10 @@ import           Aws.Signature
 import           Aws.Transaction
 import           Control.Applicative
 import           Data.Maybe
-import           Text.XML.Enumerator.Cursor   (($//), (&/))
+import           Text.XML.Cursor              (($//), (&/))
 import qualified Data.Text                    as T
 import qualified Data.Text.Encoding           as TE
-import qualified Text.XML.Enumerator.Cursor   as Cu
+import qualified Text.XML.Cursor              as Cu
 
 data ListQueues = ListQueues {
   lqQueueNamePrefix :: Maybe T.Text
@@ -24,18 +24,18 @@ data ListQueuesResponse = ListQueuesResponse{
   lqrQueueUrls :: [T.Text]
 } deriving (Show)
 
-instance ResponseIteratee r ListQueuesResponse where
+instance ResponseConsumer r ListQueuesResponse where
     type ResponseMetadata ListQueuesResponse = SqsMetadata
-    responseIteratee _ = sqsXmlResponseIteratee parse
+    responseConsumer _ = sqsXmlResponseConsumer parse
       where
-        parse el = do 
+        parse el = do
             let queues = el $// Cu.laxElement "QueueUrl" &/ Cu.content
             return ListQueuesResponse { lqrQueueUrls = queues }
-          
-instance SignQuery ListQueues where 
+
+instance SignQuery ListQueues where
     type Info ListQueues = SqsInfo
-    signQuery ListQueues{..} = sqsSignQuery SqsQuery { 
-                                              sqsQueueName = Nothing, 
+    signQuery ListQueues{..} = sqsSignQuery SqsQuery {
+                                              sqsQueueName = Nothing,
                                               sqsQuery = [("Action", Just "ListQueues")] ++ catMaybes [
                                               ("QueueNamePrefix",) <$> case lqQueueNamePrefix of
                                                                          Just x  -> Just $ Just $ TE.encodeUtf8 x

--- a/Aws/Sqs/Commands/RemovePermission.hs
+++ b/Aws/Sqs/Commands/RemovePermission.hs
@@ -21,9 +21,9 @@ data RemovePermission = RemovePermission{
 data RemovePermissionResponse = RemovePermissionResponse{
 } deriving (Show)
 
-instance ResponseIteratee r RemovePermissionResponse where
+instance ResponseConsumer r RemovePermissionResponse where
     type ResponseMetadata RemovePermissionResponse = SqsMetadata
-    responseIteratee _ = sqsXmlResponseIteratee parse
+    responseConsumer _ = sqsXmlResponseConsumer parse
       where 
         parse _ = do
           return RemovePermissionResponse {}  

--- a/Aws/Sqs/Commands/SetQueueAttributes.hs
+++ b/Aws/Sqs/Commands/SetQueueAttributes.hs
@@ -22,9 +22,9 @@ data SetQueueAttributes = SetQueueAttributes{
 data SetQueueAttributesResponse = SetQueueAttributesResponse{
 } deriving (Show)
 
-instance ResponseIteratee r SetQueueAttributesResponse where
+instance ResponseConsumer r SetQueueAttributesResponse where
     type ResponseMetadata SetQueueAttributesResponse = SqsMetadata
-    responseIteratee _ = sqsXmlResponseIteratee parse
+    responseConsumer _ = sqsXmlResponseConsumer parse
       where 
         parse _ = do
           return SetQueueAttributesResponse {}

--- a/Aws/Transaction.hs
+++ b/Aws/Transaction.hs
@@ -6,5 +6,5 @@ import Aws.Response
 import Aws.Signature
 import Data.Monoid
 
-class (SignQuery r, ResponseIteratee r a, Monoid (ResponseMetadata a))
+class (SignQuery r, ResponseConsumer r a, Monoid (ResponseMetadata a))
     => Transaction r a | r -> a, a -> r

--- a/Aws/Util.hs
+++ b/Aws/Util.hs
@@ -2,7 +2,7 @@
 
 module Aws.Util
 where
-  
+
 import           Control.Arrow
 import           Control.Exception
 import           Data.ByteString.Char8 ({- IsString -})
@@ -10,15 +10,13 @@ import           Data.Char
 import           Data.Time
 import           Data.Word
 import           System.Locale
+import qualified Control.Exception.Lifted
 import qualified Data.ByteString       as B
 import qualified Data.ByteString.UTF8  as BU
-import qualified Data.Enumerator       as En
+import qualified Data.Conduit          as C
 
-tryError :: (Exception e, Monad m) => En.Iteratee a m b -> En.Iteratee a m (Either e b)
-tryError m = En.catchError (fmap Right m) h
-    where h e = case fromException e of
-                  Just v -> return $ Left v
-                  Nothing -> En.throwError e
+tryError :: (Exception e, C.ResourceIO m) => m b -> m (Either e b)
+tryError = Control.Exception.Lifted.try
 
 queryList :: (a -> [(B.ByteString, B.ByteString)]) -> B.ByteString -> [a] -> [(B.ByteString, B.ByteString)]
 queryList f prefix xs = concat $ zipWith combine prefixList (map f xs)
@@ -52,7 +50,7 @@ readHex2 :: [Char] -> Maybe Word8
 readHex2 [c1,c2] = do n1 <- readHex1 c1
                       n2 <- readHex1 c2
                       return . fromIntegral $ n1 * 16 + n2
-    where 
+    where
       readHex1 c | c >= '0' && c <= '9' = Just $ ord c - ord '0'
                  | c >= 'A' && c <= 'F' = Just $ ord c - ord 'A' + 10
                  | c >= 'a' && c <= 'f' = Just $ ord c - ord 'a' + 10

--- a/aws.cabal
+++ b/aws.cabal
@@ -6,7 +6,7 @@ Name:                aws
 -- The package version. See the Haskell package versioning policy
 -- (http://www.haskell.org/haskellwiki/Package_versioning_policy) for
 -- standards guiding when and how versions should be incremented.
-Version:             0.0.6
+Version:             0.1
 
 -- A short (one-line) description of the package.
 Synopsis:            Amazon Web Services (AWS) for Haskell
@@ -110,41 +110,40 @@ Library
                        Aws.Transaction,
                        Aws.Util,
                        Aws.Xml
-  
+
   -- Packages needed in order to build this package.
-  Build-depends:
-                       attempt >=0.3.1.1 && <0.4,
-                       base ==4.*,
-                       base64-bytestring ==0.1.*,
-                       blaze-builder >=0.2.1.4 && <0.4,
-                       bytestring ==0.9.*,
-                       case-insensitive >=0.2 && <0.3,
-                       cereal ==0.3.*,
-                       containers >=0.3 && <0.5,
-                       crypto-api >= 0.5 && < 0.7,
-                       cryptohash >= 0.6 && < 0.8,
-                       directory >=1.0 && <1.2,
-                       enumerator ==0.4.*,
-                       failure >=0.1.0.1 && <0.2,
-                       filepath >=1.1 && <1.3,
-                       http-enumerator >=0.6.7 && < 0.7,
-                       http-types >=0.6 && <0.7,
-                       mtl ==2.*,
-                       old-locale ==1.*,
-                       shortcircuit ==0.1.*,
-                       text >= 0.11,
-                       time >=1.1.4 && <1.3,
-                       tls >= 0.7.1,
-                       transformers >=0.2.2.0 && <0.3,
-                       transformers-compose ==0.1.*,
-                       utf8-string ==0.3.*,
-                       xml-enumerator >= 0.3.4
+  Build-depends:       attempt              >= 0.3.1.1 && < 0.4,
+                       base                 == 4.*,
+                       base64-bytestring    == 0.1.*,
+                       blaze-builder        >= 0.2.1.4 && < 0.4,
+                       bytestring           == 0.9.*,
+                       case-insensitive     >= 0.2     && < 0.5,
+                       cereal               == 0.3.*,
+                       conduit              >= 0.0     && < 0.1,
+                       crypto-api           >= 0.5     && < 0.9,
+                       cryptohash           >= 0.6     && < 0.8,
+                       directory            >= 1.0     && < 1.2,
+                       failure              >= 0.1.0.1 && < 0.2,
+                       filepath             >= 1.1     && < 1.3,
+                       http-conduit         >= 1.0     && < 1.1,
+                       http-types           >= 0.6     && < 0.7,
+                       lifted-base          == 0.1.*,
+                       mtl                  == 2.*,
+                       old-locale           == 1.*,
+                       shortcircuit         == 0.1.*,
+                       text                 >= 0.11,
+                       time                 >= 1.1.4   && < 1.3,
+                       tls                  >= 0.7.1,
+                       transformers         >= 0.2.2.0 && < 0.3,
+                       transformers-compose == 0.1.*,
+                       utf8-string          == 0.3.*,
+                       xml-conduit          >= 0.5.0
 
   GHC-Options: -Wall
-  
+
   -- Modules not exported by this package.
-  -- Other-modules:       
-  
+  -- Other-modules:
+
   -- Extra tools (e.g. alex, hsc2hs, ...) needed to build the source.
-  -- Build-tools:         
-  
+  -- Build-tools:
+


### PR DESCRIPTION
I wanted to use 'aws' but it didn't work with current versions of its dependencies.  So I've updated all upper bounds and changed enumerators to conduits.
- Use conduit libraries (conduit, http-conduit, xml-conduit).
- Use lifted-base.
- Updated upper bound on case-insensitive and crypto-api.

Aristid, is this okay?  

Thanks!
