### PR TITLE
Correctly base64 encode the Content-MD5 hash

### DIFF
--- a/Aws/Core.hs
+++ b/Aws/Core.hs
@@ -334,7 +334,7 @@ queryToHttpRequest SignedQuery{..}
       , HTTP.queryString = HTTP.renderQuery False sqQuery
       , HTTP.requestHeaders = catMaybes [fmap (\d -> ("Date", fmtRfc822Time d)) sqDate
                                         , fmap (\c -> ("Content-Type", c)) contentType
-                                        , fmap (\md5 -> ("Content-MD5", Serialize.encode md5)) sqContentMd5
+                                        , fmap (\md5 -> ("Content-MD5", Base64.encode $ Serialize.encode md5)) sqContentMd5
                                         , fmap (\auth -> ("Authorization", auth)) sqAuthorization]
                               ++ sqAmzHeaders
                               ++ sqOtherHeaders

--- a/Aws/S3/Core.hs
+++ b/Aws/S3/Core.hs
@@ -22,6 +22,7 @@ import qualified Control.Failure                as F
 import qualified Crypto.Hash.MD5                as MD5
 import qualified Data.ByteString                as B
 import qualified Data.ByteString.Char8          as B8
+import qualified Data.ByteString.Base64         as Base64
 import qualified Data.CaseInsensitive           as CI
 import qualified Data.Conduit                   as C
 import qualified Data.Serialize                 as Serialize
@@ -179,7 +180,7 @@ s3SignQuery S3Query{..} S3Configuration{..} SignatureData{..}
       sig = signature signatureCredentials HmacSHA1 stringToSign
       stringToSign = Blaze.toByteString . mconcat . intersperse (Blaze8.fromChar '\n') . concat  $
                        [[Blaze.copyByteString $ httpMethod s3QMethod]
-                       , [maybe mempty (Blaze.copyByteString . Serialize.encode) s3QContentMd5]
+                       , [maybe mempty (Blaze.copyByteString . Base64.encode . Serialize.encode) s3QContentMd5]
                        , [maybe mempty Blaze.copyByteString s3QContentType]
                        , [Blaze.copyByteString $ case ti of
                                                    AbsoluteTimestamp time -> fmtRfc822Time time


### PR DESCRIPTION
When I executed a `putObject` S3 command which had a Content-MD5 hash the request could not be authenticated. I checked the source and noticed the md5 hash wasn't being base64 encoded which is required by Amazon. 
