### PR TITLE
Add goResponseContentRange GET object request field

### DIFF
--- a/Aws/S3/Commands/GetObject.hs
+++ b/Aws/S3/Commands/GetObject.hs
@@ -25,11 +25,12 @@ data GetObject
       , goResponseCacheControl :: Maybe T.Text
       , goResponseContentDisposition :: Maybe T.Text
       , goResponseContentEncoding :: Maybe T.Text
+      , goResponseContentRange :: Maybe (Int,Int)
       }
   deriving (Show)
 
 getObject :: Bucket -> T.Text -> GetObject
-getObject b o = GetObject b o Nothing Nothing Nothing Nothing Nothing Nothing Nothing
+getObject b o = GetObject b o Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing
 
 data GetObjectResponse
     = GetObjectResponse {
@@ -62,9 +63,12 @@ instance SignQuery GetObject where
                                  , s3QContentType = Nothing
                                  , s3QContentMd5 = Nothing
                                  , s3QAmzHeaders = []
-                                 , s3QOtherHeaders = []
+                                 , s3QOtherHeaders = catMaybes [
+                                                       decodeRange <$> goResponseContentRange
+                                                     ]
                                  , s3QRequestBody = Nothing
                                  }
+      where decodeRange (pos,len) = ("range",B8.concat $ ["bytes=", B8.pack (show pos), "-", B8.pack (show len)])
 
 instance ResponseConsumer GetObject GetObjectResponse where
     type ResponseMetadata GetObjectResponse = S3Metadata


### PR DESCRIPTION
Example of usage:

```
let req    = (getObject bucket filepath)
               { goResponseContentRange = Just (3,6) }
```

The 3 and 6 are passed directly on to the HTTP Range header, so their meaning is defined by that specification, where 3 is the byte offset of the first char, and 6 is the byte offset of the last char (which means the range is inclusive).
