### PR TITLE
Added helper to get all S3 objects

### DIFF
--- a/Aws/S3/Commands/GetBucket.hs
+++ b/Aws/S3/Commands/GetBucket.hs
@@ -13,6 +13,7 @@ import qualified Data.Text.Encoding    as T
 import qualified Data.Traversable
 import qualified Network.HTTP.Types    as HTTP
 import qualified Text.XML.Cursor       as Cu
+import qualified Control.Monad.Trans.Resource as R
 
 data GetBucket
     = GetBucket {
@@ -34,6 +35,34 @@ getBucket bucket
       , gbPrefix    = Nothing
       }
 
+-- | Get the ObjectInfo for all objects in a GetBucket request.
+-- 
+-- This will paginate through the markers while the request is truncated.
+-- 
+-- This considers if a delimiter was set.
+-- 
+-- Note that this will take a long time for requests that match lots of objects.
+-- 
+-- Usage:
+-- @
+--     cfg <- Aws.baseConfiguration;
+--     let s3cfg = Aws.defServiceConfig :: S3Configuration Aws.NormalQuery;
+--     rsp <- withManager $ \mgr ->
+--       getAllObjects (Aws.pureAws cfg s3cfg mgr) (getBucket name)
+-- @
+getAllObjects :: (GetBucket -> R.ResourceT IO GetBucketResponse)
+                 -> GetBucket
+                 -> R.ResourceT IO [ObjectInfo]
+getAllObjects env r = fmap (concat . reverse) $ go r []
+  where
+    go req xs = do
+      gbr :: GetBucketResponse <- env req
+      -- nextMarker is set if a delimiter was used
+      let next = maybe (objectKey (last (gbrContents gbr))) id (gbrNextMarker gbr)
+      if gbrIsTruncated gbr == True
+        then go (req { gbMarker = Just next }) ((gbrContents gbr) : xs)
+        else return ((gbrContents gbr) : xs)
+
 data GetBucketResponse
     = GetBucketResponse {
         gbrName           :: Bucket
@@ -44,6 +73,7 @@ data GetBucketResponse
       , gbrContents       :: [ObjectInfo]
       , gbrCommonPrefixes :: [T.Text]
       , gbrIsTruncated    :: Bool
+      , gbrNextMarker     :: Maybe T.Text
       }
     deriving (Show)
 
@@ -76,6 +106,7 @@ instance ResponseConsumer r GetBucketResponse where
                   = do name <- force "Missing Name" $ cursor $/ elContent "Name"
                        let delimiter = listToMaybe $ cursor $/ elContent "Delimiter"
                        let marker = listToMaybe $ cursor $/ elContent "Marker"
+                       let nextMarker = listToMaybe $ cursor $/ elContent "NextMarker"
                        maxKeys <- Data.Traversable.sequence . listToMaybe $ cursor $/ elContent "MaxKeys" &| textReadInt
                        let truncated = maybe True (/= "false") $ listToMaybe $ cursor $/ elContent "IsTruncated"
                        let prefix = listToMaybe $ cursor $/ elContent "Prefix"
@@ -90,6 +121,7 @@ instance ResponseConsumer r GetBucketResponse where
                                               , gbrContents       = contents
                                               , gbrCommonPrefixes = commonPrefixes
                                               , gbrIsTruncated    = truncated
+                                              , gbrNextMarker     = nextMarker
                                               }
 
 instance Transaction GetBucket GetBucketResponse


### PR DESCRIPTION
A helper function to paginate through a GetObject request to fetch all the objects' `ObjectInfo`.
It pages while `isTruncated` is true.

Unfortunately, the type signature doesn't play well in practice. This is because you can not run it from inside an `aws` monad conventionally. Instead you have to call it with a `ResourceT`.

If you have any ideas how to clean it up, I would be interested. Otherwise, it is very useful anyway.
