### PR TITLE
Modified iso8601-parser

### DIFF
--- a/Aws/Core.hs
+++ b/Aws/Core.hs
@@ -636,6 +636,8 @@ parseHttpDate :: String -> Maybe UTCTime
 parseHttpDate s =     p "%a, %d %b %Y %H:%M:%S GMT" s -- rfc1123-date
                   <|> p "%A, %d-%b-%y %H:%M:%S GMT" s -- rfc850-date
                   <|> p "%a %b %_d %H:%M:%S %Y" s     -- asctime-date
+                  <|> p "%Y-%m-%dT%H:%M:%S%QZ" s      -- iso 8601
+                  <|> p "%Y-%m-%dT%H:%M:%S%Q%Z" s     -- iso 8601
   where p = parseTime defaultTimeLocale
 
 -- | HTTP-date (section 3.3.1 of RFC 2616, first type - RFC1123-style)

--- a/Aws/S3/Core.hs
+++ b/Aws/S3/Core.hs
@@ -14,6 +14,7 @@ import           Data.IORef
 import           Data.List
 import           Data.Maybe
 import           Data.Monoid
+import           Control.Applicative            ((<|>))
 import           Data.Time
 import           Data.Typeable
 import           System.Locale
@@ -359,7 +360,8 @@ data ObjectInfo
 parseObjectInfo :: MonadThrow m => Cu.Cursor -> m ObjectInfo
 parseObjectInfo el
     = do key <- force "Missing object Key" $ el $/ elContent "Key"
-         let time s = case parseTime defaultTimeLocale "%Y-%m-%dT%H:%M:%S%QZ" $ T.unpack s of
+         let time s = case (parseTime defaultTimeLocale "%Y-%m-%dT%H:%M:%S%QZ" $ T.unpack s) <|>
+                           (parseTime defaultTimeLocale "%Y-%m-%dT%H:%M:%S%Q%Z" $ T.unpack s) of
                         Nothing -> throwM $ XmlException "Invalid time"
                         Just v -> return v
          lastModified <- forceM "Missing object LastModified" $ el $/ elContent "LastModified" &| time


### PR DESCRIPTION
parseTime causes XmlException when time-format is not utc.
So I modified the parser.
