### PR TITLE
Relicense modules tests/Utils.hs and tests/Sqs/Main.hs from MIT to BSD3.

### DIFF
--- a/tests/Sqs/Main.hs
+++ b/tests/Sqs/Main.hs
@@ -10,7 +10,7 @@
 -- |
 -- Module: Main
 -- Copyright: Copyright © 2014 AlephCloud Systems, Inc.
--- License: MIT
+-- License: BSD3
 -- Maintainer: Lars Kuhtz <lars@alephcloud.com>
 -- Stability: experimental
 --

--- a/tests/Utils.hs
+++ b/tests/Utils.hs
@@ -6,7 +6,7 @@
 -- |
 -- Module: Utils
 -- Copyright: Copyright © 2014 AlephCloud Systems, Inc.
--- License: MIT
+-- License: BSD3
 -- Maintainer: Lars Kuhtz <lars@alephcloud.com>
 -- Stability: experimental
 --


### PR DESCRIPTION
This change was requested as part of the merge of pull request #113
