### PR TITLE
Fix CondOp JSON rendering for nullary conditional operators

### DIFF
--- a/Aws/DynamoDb/Core.hs
+++ b/Aws/DynamoDb/Core.hs
@@ -973,10 +973,13 @@ conditionJson Condition{..} = condAttr .= condOp
 
 
 instance ToJSON CondOp where
-    toJSON c = object
-      [ "ComparisonOperator" .= String (renderCondOp c)
-      , "AttributeValueList" .= getCondValues c ]
-
+    toJSON c = object $ ("ComparisonOperator" .= String (renderCondOp c)) : valueList
+      where
+        valueList =
+          let vs = getCondValues c in
+            if null vs
+            then []
+            else ["AttributeValueList" .= vs]
 
 -------------------------------------------------------------------------------
 dyApiVersion :: B.ByteString


### PR DESCRIPTION
`AttributeValueList` must only be rendered when it is to contain at least one element. Rendering an empty `AttributeValueList` will result in a 500 error; this occurs when using a nullary conditional operator such as `IsNull` or `NotNull`.
