### PR TITLE
CreationDateTime must be an optional field in TableDescription

### DIFF
--- a/Aws/DynamoDb/Commands/Table.hs
+++ b/Aws/DynamoDb/Commands/Table.hs
@@ -266,7 +266,7 @@ data TableDescription
       , rCreationDateTime       :: Maybe UTCTime
       , rItemCount              :: Integer
       , rAttributeDefinitions   :: [AttributeDefinition]
-      , rKeySchema              :: KeySchema
+      , rKeySchema              :: Maybe KeySchema
       , rProvisionedThroughput  :: ProvisionedThroughputStatus
       , rLocalSecondaryIndexes  :: [LocalSecondaryIndexStatus]
       , rGlobalSecondaryIndexes :: [GlobalSecondaryIndexStatus]
@@ -285,7 +285,7 @@ instance A.FromJSON TableDescription where
                          <*> (fmap (posixSecondsToUTCTime . fromInteger) <$> t .:? "CreationDateTime")
                          <*> t .: "ItemCount"
                          <*> t .: "AttributeDefinitions"
-                         <*> t .: "KeySchema"
+                         <*> t .:? "KeySchema"
                          <*> t .: "ProvisionedThroughput"
                          <*> t .:? "LocalSecondaryIndexes" .!= []
                          <*> t .:? "GlobalSecondaryIndexes" .!= []


### PR DESCRIPTION
See the DynamoDB documentation which specifies this field as not required:
http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_TableDescription.html#DDB-Type-TableDescription-CreationDateTime. Likewise, `KeySchema` is not required.

Previously, if a `DeleteTable` request responded with a table description which lacked `CreationDateTime` (which can happen), an exception would be thrown in parsing the response.

This is meant to resolve #128.
