### PR TITLE
DynamoDb: fix ToJSON instance of UpdateTable

### DIFF
--- a/Aws/DynamoDb/Commands/Table.hs
+++ b/Aws/DynamoDb/Commands/Table.hs
@@ -391,7 +391,12 @@ data UpdateTable
       }
     deriving (Show, Generic)
 instance A.ToJSON UpdateTable where
-    toJSON = A.genericToJSON $ dropOpt 6
+    toJSON a = A.object
+        $ "TableName" .= updateTableName a
+        : "ProvisionedThroughput" .= updateProvisionedThroughput a
+        : case updateGlobalSecondaryIndexUpdates a of
+            [] -> []
+            l -> [ "GlobalSecondaryIndexUpdates" .= l ]
 
 -- | ServiceConfiguration: 'DdbConfiguration'
 instance SignQuery UpdateTable where


### PR DESCRIPTION
The [AWS DynamoDb API for UpdateTable](http://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_UpdateTable.html#API_UpdateTable_RequestSyntax) requires that the `GlobalSecondaryIndexUpdates` parameter is "an array of **one or more** global secondary indexes...". The generic `ToJSON` instance for lists encodes empty lists as empty arrays. This patch fixes the `ToJSON` instance of `UpdateTable` to conform with the DynamoDb API.
