### PR TITLE
Remove reverse-dependency for ghc 7.6's aws-ec2

### DIFF
--- a/Aws/Core.hs
+++ b/Aws/Core.hs
@@ -230,10 +230,10 @@ class ListResponse resp item | resp -> item where
 -- resides in 'SignQuery' and 'ResponseConsumer' respectively.
 class (SignQuery r, ResponseConsumer r a, Loggable (ResponseMetadata a))
       => Transaction r a
-      | r -> a, a -> r
+      | r -> a
 
 -- | A transaction that may need to be split over multiple requests, for example because of upstream response size limits.
-class Transaction r a => IteratedTransaction r a | r -> a , a -> r where
+class Transaction r a => IteratedTransaction r a | r -> a where
     nextIteratedRequest :: r -> a -> Maybe r
 
 -- | Signature version 4: ((region, service),(date,key))


### PR DESCRIPTION
Currently Transaction's functional dependency has both a->r and r-> a.
I think "a" is request and "r" is response, so r->a is not needed.
In ghc7.6, r->a causes compile-error for aws-ec2(https://github.com/junjihashimoto/aws-ec2).
compile-error is 
https://gist.github.com/junjihashimoto/c4ad857d459e91b20cb5
.
