### PR TITLE
Dynamodb error message parsing

### DIFF
--- a/Aws/DynamoDb/Core.hs
+++ b/Aws/DynamoDb/Core.hs
@@ -828,7 +828,7 @@ data AmazonError = AmazonError {
 instance FromJSON AmazonError where
     parseJSON (Object v) = AmazonError
         <$> v .: "__type"
-        <*> (v .:? "message" <|> v .:? "Message")
+        <*> (Just <$> (v .: "message" <|> v .: "Message") <|> pure Nothing)
     parseJSON _ = error $ "aws: unexpected AmazonError message"
 
 

--- a/Aws/DynamoDb/Core.hs
+++ b/Aws/DynamoDb/Core.hs
@@ -828,7 +828,7 @@ data AmazonError = AmazonError {
 instance FromJSON AmazonError where
     parseJSON (Object v) = AmazonError
         <$> v .: "__type"
-        <*> v .:? "message"
+        <*> (v .:? "message" <|> v .:? "Message")
     parseJSON _ = error $ "aws: unexpected AmazonError message"
 
 

--- a/default.nix
+++ b/default.nix
@@ -1,2 +1,2 @@
 { pkgs ? import <nixpkgs> {} }:
-pkgs.haskellPackages_ghc783_profiling.callPackage ./aws.nix {}
+pkgs.haskellPackages_ghc784_profiling.callPackage ./aws.nix {}


### PR DESCRIPTION
AccessDenied exceptions seem to have their message in "Message", not "message" according to #146 

CC @ozataman @glasserc