### PR TITLE
No longer builds on GHC <=7.4

### DIFF
--- a/aws.cabal
+++ b/aws.cabal
@@ -111,7 +111,7 @@ Library
   Build-depends:
                        aeson                >= 0.6,
                        attoparsec           >= 0.11    && < 0.13,
-                       base                 == 4.*,
+                       base                 >= 4.6     && < 5,
                        base16-bytestring    == 0.1.*,
                        base16-bytestring    == 0.1.*,
                        base64-bytestring    == 1.0.*,


### PR DESCRIPTION
```
Aws/Network.hs:16:12:
    Ambiguous occurrence `catch'
    It could refer to either `Prelude.catch',
                             imported from `Prelude' at Aws/Network.hs:1:8-18
                             (and originally defined in `System.IO.Error')
                          or `Control.Exception.catch',
                             imported from `Control.Exception' at Aws/Network.hs:4:1-24
                             (and originally defined in `Control.Exception.Base')
xcabal: Error: some packages failed to install:
```

7.4 compat broke in aws-0.9.2. I've revised all offending versions.