### PR TITLE
Add dynamodb boolean datatype

### DIFF
--- a/Aws/DynamoDb/Core.hs
+++ b/Aws/DynamoDb/Core.hs
@@ -1128,6 +1128,7 @@ class DynSize a where
 
 instance DynSize DValue where
     dynSize (DBool _) = 8
+    dynSize (DBoolSet s) = sum $ map (dynSize . DBool) $ S.toList s
     dynSize (DNum _) = 8
     dynSize (DString a) = T.length a
     dynSize (DBinary bs) = T.length . T.decodeUtf8 $ Base64.encode bs

--- a/aws.cabal
+++ b/aws.cabal
@@ -1,5 +1,5 @@
 Name:                aws
-Version:             0.12.1
+Version:             0.12.2
 Synopsis:            Amazon Web Services (AWS) for Haskell
 Description:         Bindings for Amazon Web Services (AWS), with the aim of supporting all AWS services. To see a high level overview of the library, see the README at <https://github.com/aristidb/aws/blob/master/README.org>.
 Homepage:            http://github.com/aristidb/aws
@@ -285,7 +285,7 @@ Executable Sqs
     Build-depends:
                        base == 4.*,
                        aws,
-                       errors >= 1.4 && < 2.0,
+                       errors >= 2.0 && <= 2.1,
                        text >=0.11,
                        transformers >= 0.3
 
@@ -306,7 +306,7 @@ test-suite sqs-tests
         aws,
         base == 4.*,
         bytestring >= 0.10,
-        errors >= 1.4.7 && < 2.0,
+        errors >= 2.0 && < 2.1,
         http-client >= 0.3,
         lifted-base >= 0.2,
         monad-control >= 0.3,
@@ -339,7 +339,7 @@ test-suite dynamodb-tests
         aws,
         base == 4.*,
         bytestring >= 0.10,
-        errors >= 1.4.7 && < 2.0,
+        errors >= 2.0 && < 2.1,
         http-client >= 0.3,
         lifted-base >= 0.2,
         monad-control >= 0.3,

--- a/aws.cabal
+++ b/aws.cabal
@@ -1,5 +1,5 @@
 Name:                aws
-Version:             0.12.2
+Version:             0.13.0
 Synopsis:            Amazon Web Services (AWS) for Haskell
 Description:         Bindings for Amazon Web Services (AWS), with the aim of supporting all AWS services. To see a high level overview of the library, see the README at <https://github.com/aristidb/aws/blob/master/README.org>.
 Homepage:            http://github.com/aristidb/aws
@@ -285,7 +285,7 @@ Executable Sqs
     Build-depends:
                        base == 4.*,
                        aws,
-                       errors >= 1.4.7 && <= 2.0,
+                       errors >= 1.4.7 && < 2.0,
                        text >=0.11,
                        transformers >= 0.3
 

--- a/aws.cabal
+++ b/aws.cabal
@@ -291,66 +291,66 @@ Executable Sqs
 
   Default-Language: Haskell2010
 
--- test-suite sqs-tests
---     type: exitcode-stdio-1.0
---     default-language: Haskell2010
---     hs-source-dirs: tests
---     main-is: Sqs/Main.hs
+test-suite sqs-tests
+    type: exitcode-stdio-1.0
+    default-language: Haskell2010
+    hs-source-dirs: tests
+    main-is: Sqs/Main.hs
 
---     other-modules:
---         Utils
+    other-modules:
+        Utils
 
---     build-depends:
---         QuickCheck >= 2.7,
---         aeson >= 0.7,
---         aws,
---         base == 4.*,
---         bytestring >= 0.10,
---         errors >= 1.4.7 && < 2.0,
---         http-client >= 0.3,
---         lifted-base >= 0.2,
---         monad-control >= 0.3,
---         mtl >= 2.1,
---         quickcheck-instances >= 0.3,
---         resourcet >= 1.1,
---         tagged >= 0.7,
---         tasty >= 0.8,
---         tasty-quickcheck >= 0.8,
---         text >= 1.1,
---         time,
---         transformers >= 0.3,
---         transformers-base >= 0.4
+    build-depends:
+        QuickCheck >= 2.7,
+        aeson >= 0.7,
+        aws,
+        base == 4.*,
+        bytestring >= 0.10,
+        errors >= 1.4.7 && < 2.0,
+        http-client >= 0.3,
+        lifted-base >= 0.2,
+        monad-control >= 0.3,
+        mtl >= 2.1,
+        quickcheck-instances >= 0.3,
+        resourcet >= 1.1,
+        tagged >= 0.7,
+        tasty >= 0.8,
+        tasty-quickcheck >= 0.8,
+        text >= 1.1,
+        time,
+        transformers >= 0.3,
+        transformers-base >= 0.4
 
---     ghc-options: -Wall -threaded
+    ghc-options: -Wall -threaded
 
--- test-suite dynamodb-tests
---     type: exitcode-stdio-1.0
---     default-language: Haskell2010
---     hs-source-dirs: tests
---     main-is: DynamoDb/Main.hs
+test-suite dynamodb-tests
+    type: exitcode-stdio-1.0
+    default-language: Haskell2010
+    hs-source-dirs: tests
+    main-is: DynamoDb/Main.hs
 
---     other-modules:
---         Utils
---         DynamoDb.Utils
+    other-modules:
+        Utils
+        DynamoDb.Utils
 
---     build-depends:
---         QuickCheck >= 2.7,
---         aeson >= 0.7,
---         aws,
---         base == 4.*,
---         bytestring >= 0.10,
---         errors >= 1.4.7 && < 2.0,
---         http-client >= 0.3,
---         lifted-base >= 0.2,
---         monad-control >= 0.3,
---         mtl >= 2.1,
---         quickcheck-instances >= 0.3,
---         resourcet >= 1.1,
---         tagged >= 0.7,
---         tasty >= 0.8,
---         tasty-quickcheck >= 0.8,
---         text >= 1.1,
---         time,
---         transformers >= 0.3,
---         transformers-base >= 0.4
+    build-depends:
+        QuickCheck >= 2.7,
+        aeson >= 0.7,
+        aws,
+        base == 4.*,
+        bytestring >= 0.10,
+        errors >= 1.4.7 && < 2.0,
+        http-client >= 0.3,
+        lifted-base >= 0.2,
+        monad-control >= 0.3,
+        mtl >= 2.1,
+        quickcheck-instances >= 0.3,
+        resourcet >= 1.1,
+        tagged >= 0.7,
+        tasty >= 0.8,
+        tasty-quickcheck >= 0.8,
+        text >= 1.1,
+        time,
+        transformers >= 0.3,
+        transformers-base >= 0.4
 

--- a/aws.cabal
+++ b/aws.cabal
@@ -291,66 +291,66 @@ Executable Sqs
 
   Default-Language: Haskell2010
 
-test-suite sqs-tests
-    type: exitcode-stdio-1.0
-    default-language: Haskell2010
-    hs-source-dirs: tests
-    main-is: Sqs/Main.hs
+-- test-suite sqs-tests
+--     type: exitcode-stdio-1.0
+--     default-language: Haskell2010
+--     hs-source-dirs: tests
+--     main-is: Sqs/Main.hs
 
-    other-modules:
-        Utils
+--     other-modules:
+--         Utils
 
-    build-depends:
-        QuickCheck >= 2.7,
-        aeson >= 0.7,
-        aws,
-        base == 4.*,
-        bytestring >= 0.10,
-        errors >= 1.4.7 && < 2.0,
-        http-client >= 0.3,
-        lifted-base >= 0.2,
-        monad-control >= 0.3,
-        mtl >= 2.1,
-        quickcheck-instances >= 0.3,
-        resourcet >= 1.1,
-        tagged >= 0.7,
-        tasty >= 0.8,
-        tasty-quickcheck >= 0.8,
-        text >= 1.1,
-        time,
-        transformers >= 0.3,
-        transformers-base >= 0.4
+--     build-depends:
+--         QuickCheck >= 2.7,
+--         aeson >= 0.7,
+--         aws,
+--         base == 4.*,
+--         bytestring >= 0.10,
+--         errors >= 1.4.7 && < 2.0,
+--         http-client >= 0.3,
+--         lifted-base >= 0.2,
+--         monad-control >= 0.3,
+--         mtl >= 2.1,
+--         quickcheck-instances >= 0.3,
+--         resourcet >= 1.1,
+--         tagged >= 0.7,
+--         tasty >= 0.8,
+--         tasty-quickcheck >= 0.8,
+--         text >= 1.1,
+--         time,
+--         transformers >= 0.3,
+--         transformers-base >= 0.4
 
-    ghc-options: -Wall -threaded
+--     ghc-options: -Wall -threaded
 
-test-suite dynamodb-tests
-    type: exitcode-stdio-1.0
-    default-language: Haskell2010
-    hs-source-dirs: tests
-    main-is: DynamoDb/Main.hs
+-- test-suite dynamodb-tests
+--     type: exitcode-stdio-1.0
+--     default-language: Haskell2010
+--     hs-source-dirs: tests
+--     main-is: DynamoDb/Main.hs
 
-    other-modules:
-        Utils
-        DynamoDb.Utils
+--     other-modules:
+--         Utils
+--         DynamoDb.Utils
 
-    build-depends:
-        QuickCheck >= 2.7,
-        aeson >= 0.7,
-        aws,
-        base == 4.*,
-        bytestring >= 0.10,
-        errors >= 1.4.7 && < 2.0,
-        http-client >= 0.3,
-        lifted-base >= 0.2,
-        monad-control >= 0.3,
-        mtl >= 2.1,
-        quickcheck-instances >= 0.3,
-        resourcet >= 1.1,
-        tagged >= 0.7,
-        tasty >= 0.8,
-        tasty-quickcheck >= 0.8,
-        text >= 1.1,
-        time,
-        transformers >= 0.3,
-        transformers-base >= 0.4
+--     build-depends:
+--         QuickCheck >= 2.7,
+--         aeson >= 0.7,
+--         aws,
+--         base == 4.*,
+--         bytestring >= 0.10,
+--         errors >= 1.4.7 && < 2.0,
+--         http-client >= 0.3,
+--         lifted-base >= 0.2,
+--         monad-control >= 0.3,
+--         mtl >= 2.1,
+--         quickcheck-instances >= 0.3,
+--         resourcet >= 1.1,
+--         tagged >= 0.7,
+--         tasty >= 0.8,
+--         tasty-quickcheck >= 0.8,
+--         text >= 1.1,
+--         time,
+--         transformers >= 0.3,
+--         transformers-base >= 0.4
 

--- a/aws.cabal
+++ b/aws.cabal
@@ -285,7 +285,7 @@ Executable Sqs
     Build-depends:
                        base == 4.*,
                        aws,
-                       errors >= 2.0 && <= 2.1,
+                       errors >= 1.4.7 && <= 2.0,
                        text >=0.11,
                        transformers >= 0.3
 
@@ -306,7 +306,7 @@ test-suite sqs-tests
         aws,
         base == 4.*,
         bytestring >= 0.10,
-        errors >= 2.0 && < 2.1,
+        errors >= 1.4.7 && < 2.0,
         http-client >= 0.3,
         lifted-base >= 0.2,
         monad-control >= 0.3,
@@ -339,7 +339,7 @@ test-suite dynamodb-tests
         aws,
         base == 4.*,
         bytestring >= 0.10,
-        errors >= 2.0 && < 2.1,
+        errors >= 1.4.7 && < 2.0,
         http-client >= 0.3,
         lifted-base >= 0.2,
         monad-control >= 0.3,

--- a/config.nix
+++ b/config.nix
@@ -1,0 +1,7 @@
+{
+  packageOverrides = pkgs: rec {
+    haskellPackages = with pkgs.haskellPackages; pkgs.haskellPackages // rec {
+       errors  = callPackage ./errors.nix {};
+     };
+  };
+}

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,34 @@
+{ mkDerivation, aeson, attoparsec, base, base16-bytestring
+, base64-bytestring, blaze-builder, byteable, bytestring
+, case-insensitive, cereal, conduit, conduit-extra, containers
+, cryptohash, data-default, directory, errors-1_4_7, filepath
+, http-client, http-conduit, http-types, lifted-base, monad-control
+, mtl, network, old-locale, QuickCheck, quickcheck-instances
+, resourcet, safe, scientific, stdenv, tagged, tasty
+, tasty-quickcheck, text, time, transformers, transformers-base
+, unordered-containers, utf8-string, vector, xml-conduit
+}:
+mkDerivation {
+  pname = "aws";
+  version = "0.12.2";
+  src = ./.;
+  isLibrary = true;
+  isExecutable = true;
+  buildDepends = [
+    aeson attoparsec base base16-bytestring base64-bytestring
+    blaze-builder byteable bytestring case-insensitive cereal conduit
+    conduit-extra containers cryptohash data-default directory filepath
+    http-conduit http-types lifted-base monad-control mtl network
+    old-locale resourcet safe scientific tagged text time transformers
+    unordered-containers utf8-string vector xml-conduit
+  ];
+  testDepends = [
+    aeson base bytestring errors-1_4_7 http-client lifted-base monad-control
+    mtl QuickCheck quickcheck-instances resourcet tagged tasty
+    tasty-quickcheck text time transformers transformers-base
+  ];
+  jailbreak = true;
+  homepage = "http://github.com/aristidb/aws";
+  description = "Amazon Web Services (AWS) for Haskell";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,7 @@
 { mkDerivation, aeson, attoparsec, base, base16-bytestring
 , base64-bytestring, blaze-builder, byteable, bytestring
 , case-insensitive, cereal, conduit, conduit-extra, containers
-, cryptohash, data-default, directory, errors-1_4_7, filepath
+, cryptohash, data-default, directory, errors, filepath
 , http-client, http-conduit, http-types, lifted-base, monad-control
 , mtl, network, old-locale, QuickCheck, quickcheck-instances
 , resourcet, safe, scientific, stdenv, tagged, tasty
@@ -23,11 +23,10 @@ mkDerivation {
     unordered-containers utf8-string vector xml-conduit
   ];
   testDepends = [
-    aeson base bytestring errors-1_4_7 http-client lifted-base monad-control
+    aeson base bytestring errors http-client lifted-base monad-control
     mtl QuickCheck quickcheck-instances resourcet tagged tasty
     tasty-quickcheck text time transformers transformers-base
   ];
-  jailbreak = true;
   homepage = "http://github.com/aristidb/aws";
   description = "Amazon Web Services (AWS) for Haskell";
   license = stdenv.lib.licenses.bsd3;

--- a/default.nix
+++ b/default.nix
@@ -10,7 +10,7 @@
 }:
 mkDerivation {
   pname = "aws";
-  version = "0.12.2";
+  version = "0.13.0";
   src = ./.;
   isLibrary = true;
   isExecutable = true;

--- a/errors.nix
+++ b/errors.nix
@@ -1,0 +1,9 @@
+{ mkDerivation, base, either, safe, stdenv, transformers }:
+mkDerivation {
+  pname = "errors";
+  version = "1.4.7";
+  sha256 = "09g53dylwsw1phxq5zhkbq8pnpwqzipvqclmcrdypzkpwkmfncl7";
+  buildDepends = [ base either safe transformers ];
+  description = "Simplified error-handling";
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,37 +1,5 @@
 with (import <nixpkgs> {}).pkgs;
-let pkg = haskellngPackages.callPackage
-            ({ mkDerivation, aeson, attoparsec, base, base16-bytestring
-             , base64-bytestring, blaze-builder, byteable, bytestring
-             , case-insensitive, cereal, conduit, conduit-extra, containers
-             , cryptohash, data-default, directory, errors, filepath
-             , http-client, http-conduit, http-types, lifted-base, monad-control
-             , mtl, network, old-locale, QuickCheck, quickcheck-instances
-             , resourcet, safe, scientific, stdenv, tagged, tasty
-             , tasty-quickcheck, text, time, transformers, transformers-base
-             , unordered-containers, utf8-string, vector, xml-conduit
-             }:
-             mkDerivation {
-               pname = "aws";
-               version = "0.12";
-               src = ./.;
-               isLibrary = true;
-               isExecutable = true;
-               buildDepends = [
-                 aeson attoparsec base base16-bytestring base64-bytestring
-                 blaze-builder byteable bytestring case-insensitive cereal conduit
-                 conduit-extra containers cryptohash data-default directory filepath
-                 http-conduit http-types lifted-base monad-control mtl network
-                 old-locale resourcet safe scientific tagged text time transformers
-                 unordered-containers utf8-string vector xml-conduit
-               ];
-               testDepends = [
-                 aeson base bytestring errors http-client lifted-base monad-control
-                 mtl QuickCheck quickcheck-instances resourcet tagged tasty
-                 tasty-quickcheck text time transformers transformers-base
-               ];
-               homepage = "http://github.com/aristidb/aws";
-               description = "Amazon Web Services (AWS) for Haskell";
-               license = stdenv.lib.licenses.bsd3;
-             }) {};
+let
+  pkg = haskellngPackages.callPackage ./. {};
 in
   pkg.env


### PR DESCRIPTION
This PR adds the following (following on from the issue described here: https://github.com/aristidb/aws/issues/173)

* Updated nix settings for build with the old errors package (superseded on the main stable nix-channel).
* Support for the native dynamodb boolean data type.

This work fixes the issue that the latest dynamodb json responses would cause an exception to be thrown when FromDynItem getAttr was called on the response set if boolean values are encoded.

I've tried to keep the code as close to the style for the other data types. It would benefit from some close scrutiny of the DynSize instance - which I'm a little unsure of.

