### PR TITLE
Picosecond calculation should be based on first epoch day instead of first MOD day

### DIFF
--- a/Aws/DynamoDb/Core.hs
+++ b/Aws/DynamoDb/Core.hs
@@ -387,38 +387,37 @@ instance DynVal UTCTime where
     fromRep num = fromTS <$> fromRep num
     toRep x = toRep (toTS x)
 
-
 -------------------------------------------------------------------------------
 pico :: Rational
 pico = toRational $ 10 ^ (12 :: Integer)
-
 
 -------------------------------------------------------------------------------
 dayPico :: Integer
 dayPico = 86400 * round pico
 
+-------------------------------------------------------------------------------
+unixEpochDay :: Day
+unixEpochDay = ModifiedJulianDay 40587
 
 -------------------------------------------------------------------------------
 -- | Convert UTCTime to picoseconds
 --
 -- TODO: Optimize performance?
 toTS :: UTCTime -> Integer
-toTS (UTCTime (ModifiedJulianDay i) diff) = i' + diff'
+toTS (UTCTime i diff) = i' + diff'
     where
       diff' = floor (toRational diff * pico)
-      i' = i * dayPico
-
+      i' = (fromInteger (diffDays i unixEpochDay)) * dayPico
 
 -------------------------------------------------------------------------------
 -- | Convert picoseconds to UTCTime
 --
 -- TODO: Optimize performance?
 fromTS :: Integer -> UTCTime
-fromTS i = UTCTime (ModifiedJulianDay days) diff
+fromTS i = UTCTime (addDays days unixEpochDay) diff
     where
       (days, secs) = i `divMod` dayPico
-      diff = fromRational ((toRational secs) / pico)
-
+      diff = fromRational ((toRational secs) / pico)   
 
 
 -- | Type wrapper for binary data to be written to DynamoDB. Wrap any


### PR DESCRIPTION
Picoseconds should be calculated based on the day of the epoch `(ModifiedJulianDay 40587)`, not the initial modified julian day `(ModifiedJulianDay 0)`.

Without this fix the number of picoseconds is very high compared to what it should be.
```haskell
λ: encode . unDynNumber .toRep <$> getCurrentTime
"4950441825298243000000" -- very high epoch time (calculated from ModifiedJulianDay 0, should be ModifiedJulianDay 40587)
λ: (*(10^(12 :: Integer))) . (round :: NominalDiffTime -> Integer)  <$> getPOSIXTime
1443725015000000000000 -- true epoch time
(0.01 secs, 4,164,632 bytes)
```

With this fix it is more in line.
```haskell
(0.01 secs, 4,697,456 bytes)
λ: (*(10^(12 :: Integer))) . (round :: NominalDiffTime -> Integer)  <$> getPOSIXTime
1443723266000000000000
(0.01 secs, 4,171,920 bytes)
λ: encode . unDynNumber <$> toRep <$> getCurrentTime 
"1443723277645993000000"
```