### PR TITLE
Add DynVal instances for V.Vector and M.Map

### DIFF
--- a/Aws/DynamoDb/Core.hs
+++ b/Aws/DynamoDb/Core.hs
@@ -379,6 +379,18 @@ instance DynVal Double where
     fromRep (DynNumber i) = Just $ toRealFloat i
     toRep i = DynNumber (fromFloatDigits i)
 
+instance DynVal a => DynVal (V.Vector a) where
+  type DynRep (V.Vector a) = DValue
+  toRep v = DList $ fmap toValue v
+  fromRep (DList l) = traverse fromValue l
+  fromRep _         = Nothing
+
+instance DynVal a => DynVal (M.Map T.Text a) where
+  type DynRep (M.Map T.Text a) = DValue
+  toRep m = DMap $ fmap toValue m
+  fromRep (DMap m) = traverse fromValue m
+  fromRep _        = Nothing
+
 
 -------------------------------------------------------------------------------
 -- | Encoded as number of days

--- a/Aws/DynamoDb/Core.hs
+++ b/Aws/DynamoDb/Core.hs
@@ -151,6 +151,7 @@ import           Data.Tagged
 import qualified Data.Text                    as T
 import qualified Data.Text.Encoding           as T
 import           Data.Time
+import           Data.Traversable             (traverse)
 import           Data.Typeable
 import qualified Data.Vector                  as V
 import           Data.Word


### PR DESCRIPTION
I think we are missing the List and Map `DynVal` instances. This is my stab at it. Feedback welcome!
What else is missing the `DMap` and `DList` changes?