### PR TITLE
Add `getItem` parser combinator to DynamoDb

### DIFF
--- a/Aws/DynamoDb/Core.hs
+++ b/Aws/DynamoDb/Core.hs
@@ -75,7 +75,7 @@ module Aws.DynamoDb.Core
     , Parser (..)
     , getAttr
     , getAttr'
-    , getItem
+    , parseAttr
 
     -- * Common types used by operations
     , Conditions (..)
@@ -1350,14 +1350,14 @@ getAttr' k m = do
       Just dv -> return $ fromValue dv
 
 -- | Combinator for parsing an attribute into a 'FromDynItem'.
-getItem
+parseAttr
     :: FromDynItem a
     => T.Text
     -- ^ Attribute name
     -> Item
     -- ^ Item from DynamoDb
     -> Parser a
-getItem k m =
+parseAttr k m =
   case M.lookup k m of
     Nothing -> fail ("Key " <> T.unpack k <> " not found")
     Just (DMap dv) -> either (fail "...") return $ fromItem dv

--- a/Aws/DynamoDb/Core.hs
+++ b/Aws/DynamoDb/Core.hs
@@ -1352,7 +1352,7 @@ getAttr' k m = do
 -- | Combinator for parsing an attribute into a 'FromDynItem'.
 getItem
     :: FromDynItem a
-    => Text
+    => T.Text
     -- ^ Attribute name
     -> Item
     -- ^ Item from DynamoDb

--- a/Aws/DynamoDb/Core.hs
+++ b/Aws/DynamoDb/Core.hs
@@ -75,6 +75,7 @@ module Aws.DynamoDb.Core
     , Parser (..)
     , getAttr
     , getAttr'
+    , getItem
 
     -- * Common types used by operations
     , Conditions (..)
@@ -1348,6 +1349,19 @@ getAttr' k m = do
       Nothing -> return Nothing
       Just dv -> return $ fromValue dv
 
+-- | Combinator for parsing an attribute into a 'FromDynItem'.
+getItem
+    :: FromDynItem a
+    => Text
+    -- ^ Attribute name
+    -> Item
+    -- ^ Item from DynamoDb
+    -> Parser a
+getItem k m =
+  case M.lookup k m of
+    Nothing -> fail ("Key " <> T.unpack k <> " not found")
+    Just (DMap dv) -> either (fail "...") return $ fromItem dv
+    _       -> fail ("Key " <> T.unpack k <> " is not a map!")
 
 -------------------------------------------------------------------------------
 -- | Parse an 'Item' into target type using the 'FromDynItem'


### PR DESCRIPTION
Adds `getItem` combinator for parsing records.

- I'm not sure if we are running into name conflicts with the other `getItem`; what other name might be appropriate?
- do we need a `getItem'` as well?
