### PR TITLE
Adds support for List and Map `DynVal`.

### DIFF
--- a/Aws/DynamoDb/Core.hs
+++ b/Aws/DynamoDb/Core.hs
@@ -151,6 +151,7 @@ import           Data.Tagged
 import qualified Data.Text                    as T
 import qualified Data.Text.Encoding           as T
 import           Data.Time
+import           Data.Traversable             (traverse)
 import           Data.Typeable
 import qualified Data.Vector                  as V
 import           Data.Word
@@ -378,6 +379,18 @@ instance DynVal Double where
     type DynRep Double = DynNumber
     fromRep (DynNumber i) = Just $ toRealFloat i
     toRep i = DynNumber (fromFloatDigits i)
+
+instance DynVal a => DynVal (V.Vector a) where
+  type DynRep (V.Vector a) = DValue
+  toRep v = DList $ fmap toValue v
+  fromRep (DList l) = traverse fromValue l
+  fromRep _         = Nothing
+
+instance DynVal a => DynVal (M.Map T.Text a) where
+  type DynRep (M.Map T.Text a) = DValue
+  toRep m = DMap $ fmap toValue m
+  fromRep (DMap m) = traverse fromValue m
+  fromRep _        = Nothing
 
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
In aristidb/aws/pull/177, @puffnfresh added support for

- Null
- Lists (L)
- Map (M)

where Lists are represented as `DList (Vector DValue)` and
Maps as `DMap (Map Text Dvalue)`.

This adds `DynVal` instances for `Vector` and `Map Text` to
allow them to be used when parsing a structure into records.