### PR TITLE
DynamoDb: Avoid overlapping ToJSON instance

### DIFF
--- a/Aws/DynamoDb/Commands/UpdateItem.hs
+++ b/Aws/DynamoDb/Commands/UpdateItem.hs
@@ -19,7 +19,15 @@
 --
 ----------------------------------------------------------------------------
 
-module Aws.DynamoDb.Commands.UpdateItem where
+module Aws.DynamoDb.Commands.UpdateItem
+    ( UpdateItem(..)
+    , updateItem
+    , AttributeUpdate(..)
+    , au
+    , UpdateAction(..)
+    , UpdateItem(..)
+    , UpdateItemResponse(..)
+    ) where
 
 -------------------------------------------------------------------------------
 import           Control.Applicative
@@ -55,7 +63,10 @@ updateItem
 updateItem tn key ups = UpdateItem tn key ups def def def def
 
 
-type AttributeUpdates = [AttributeUpdate]
+-- | A helper to avoid overlapping instances for 'ToJSON'.
+newtype AttributeUpdates = AttributeUpdates {
+    getAttributeUpdates :: [AttributeUpdate]
+    }
 
 
 data AttributeUpdate = AttributeUpdate {
@@ -77,7 +88,7 @@ au a = AttributeUpdate a def
 
 
 instance ToJSON AttributeUpdates where
-    toJSON = object . map mk
+    toJSON = object . map mk . getAttributeUpdates
         where
           mk AttributeUpdate { auAction = UDelete, auAttr = auAttr } =
             (attrName auAttr) .= object
@@ -114,7 +125,7 @@ instance ToJSON UpdateItem where
         object $ expectsJson uiExpect ++
           [ "TableName" .= uiTable
           , "Key" .= uiKey
-          , "AttributeUpdates" .= uiUpdates
+          , "AttributeUpdates" .= AttributeUpdates uiUpdates
           , "ReturnValues" .= uiReturn
           , "ReturnConsumedCapacity" .= uiRetCons
           , "ReturnItemCollectionMetrics" .= uiRetMet


### PR DESCRIPTION
Aeson 1.0 will provide a `ToJSON [a]` instance, which the previous
`ToJSON [AttributeUpdate]` instance will overlap with. This internally
wraps `[AttributeUpdate]` in a newtype.

An alternative here would be to expose `AttributeUpdates` with a singleton function and a `Monoid` instance