### PR TITLE
Fix padding in Date header for GCP compatibility

### DIFF
--- a/Aws/Core.hs
+++ b/Aws/Core.hs
@@ -727,7 +727,7 @@ fmtTime :: String -> UTCTime -> B.ByteString
 fmtTime s t = BU.fromString $ formatTime defaultTimeLocale s t
 
 rfc822Time :: String
-rfc822Time = "%a, %_d %b %Y %H:%M:%S GMT"
+rfc822Time = "%a, %0d %b %Y %H:%M:%S GMT"
 
 -- | Format time in RFC 822 format.
 fmtRfc822Time :: UTCTime -> B.ByteString

--- a/Examples/GetObjectGoogle.hs
+++ b/Examples/GetObjectGoogle.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+import qualified Aws
+import qualified Aws.Core as Aws
+import qualified Aws.S3 as S3
+import           Data.Conduit (($$+-))
+import           Data.Conduit.Binary (sinkFile)
+import           Network.HTTP.Conduit (withManager, responseBody)
+
+main :: IO ()
+main = do
+  Just creds <- Aws.loadCredentialsFromEnv
+  let cfg = Aws.Configuration Aws.Timestamp creds (Aws.defaultLog Aws.Debug)
+  let s3cfg = S3.s3 Aws.HTTP "storage.googleapis.com" False
+  {- Set up a ResourceT region with an available HTTP manager. -}
+  withManager $ \mgr -> do
+    {- Create a request object with S3.getObject and run the request with pureAws. -}
+    S3.GetObjectResponse { S3.gorResponse = rsp } <-
+      Aws.pureAws cfg s3cfg mgr $
+        {- Public bucket from GCP examples -}
+        S3.getObject "uspto-pair" "applications/05900016.zip"
+
+    {- Save the response to a file. -}
+    responseBody rsp $$+- sinkFile "getobject-test.zip"

--- a/aws.cabal
+++ b/aws.cabal
@@ -184,6 +184,23 @@ Executable GetObject
 
   Default-Language: Haskell2010
 
+Executable GetObjectGoogle
+  Main-is: GetObjectGoogle.hs
+  Hs-source-dirs: Examples
+
+  if !flag(Examples)
+    Buildable: False
+  else
+    Buildable: True
+    Build-depends:
+                       base == 4.*,
+                       aws,
+                       http-conduit,
+                       conduit,
+                       conduit-extra
+
+  Default-Language: Haskell2010
+
 Executable MultipartUpload
   Main-is: MultipartUpload.hs
   Hs-source-dirs: Examples


### PR DESCRIPTION
On single-digit days (like today), rfc822Time produces a Date header like this:
>Date: Tue,  8 Nov 2016 20:50:14 GMT

with two spaces between the comma and 8. Google's XML API rejects this, saying that a header is malformed. It seems they are being very strict in their interpretation of the RFC - if I'm reading it correctly, it specifies a comma, single space and one or two digits after that.

Anyway, changing the space to a zero seems to fix it. I checked that this does not break Amazon's S3, but didn't try any other services.
