### PR TITLE
Remove redundant dependency on base16-bytestring

### DIFF
--- a/aws.cabal
+++ b/aws.cabal
@@ -113,7 +113,6 @@ Library
                        attoparsec           >= 0.11    && < 0.14,
                        base                 >= 4.6     && < 5,
                        base16-bytestring    == 0.1.*,
-                       base16-bytestring    == 0.1.*,
                        base64-bytestring    == 1.0.*,
                        blaze-builder        >= 0.2.1.4 && < 0.5,
                        byteable             == 0.1.*,


### PR DESCRIPTION
base16-bytestring was defined twice with the same bounds.