### PR TITLE
Fix multipart upload version ids

### DIFF
--- a/aws.cabal
+++ b/aws.cabal
@@ -406,6 +406,7 @@ test-suite s3-tests
         aws,
         base == 4.*,
         bytestring,
+        conduit-combinators,
         http-client < 0.5,
         http-client-tls < 0.5,
         http-types,


### PR DESCRIPTION
Multipart uploads return version id in CompleteUpload response, not in UploadPart.

Also, I made sendEtag helper return CompleteMultipartUploadResponse. This does not break multipartUpload* API, but helps me with implementing versioned multipart uploads: one less function to copy-paste.