### PR TITLE
Fix parsing bug with table description creation date

### DIFF
--- a/Aws/DynamoDb/Commands/Table.hs
+++ b/Aws/DynamoDb/Commands/Table.hs
@@ -64,6 +64,10 @@ dropOpt :: Int -> A.Options
 dropOpt d = A.defaultOptions { A.fieldLabelModifier = drop d }
 
 
+convertToUTCTime :: Scientific -> UTCTime
+convertToUTCTime = posixSecondsToUTCTime . fromInteger . round
+
+
 -- | The type of a key attribute that appears in the table key or as a
 -- key in one of the indices.
 data AttributeType = AttrString | AttrNumber | AttrBinary
@@ -212,8 +216,8 @@ data ProvisionedThroughputStatus
 instance A.FromJSON ProvisionedThroughputStatus where
     parseJSON = A.withObject "Throughput status must be an object" $ \o ->
         ProvisionedThroughputStatus
-            <$> (posixSecondsToUTCTime . fromInteger <$> o .:? "LastDecreaseDateTime" .!= 0)
-            <*> (posixSecondsToUTCTime . fromInteger <$> o .:? "LastIncreaseDateTime" .!= 0)
+            <$> (convertToUTCTime <$> o .:? "LastDecreaseDateTime" .!= 0)
+            <*> (convertToUTCTime <$> o .:? "LastIncreaseDateTime" .!= 0)
             <*> o .:? "NumberOfDecreasesToday" .!= 0
             <*> o .: "ReadCapacityUnits"
             <*> o .: "WriteCapacityUnits"
@@ -284,7 +288,7 @@ instance A.FromJSON TableDescription where
         TableDescription <$> t .: "TableName"
                          <*> t .: "TableSizeBytes"
                          <*> t .: "TableStatus"
-                         <*> (fmap (posixSecondsToUTCTime . fromInteger . (round :: Scientific -> Integer)) <$> t .:? "CreationDateTime")
+                         <*> (fmap convertToUTCTime <$> t .:? "CreationDateTime")
                          <*> t .: "ItemCount"
                          <*> t .:? "AttributeDefinitions" .!= []
                          <*> t .:? "KeySchema"

--- a/Aws/DynamoDb/Commands/Table.hs
+++ b/Aws/DynamoDb/Commands/Table.hs
@@ -38,6 +38,7 @@ import qualified Data.Aeson            as A
 import qualified Data.Aeson.Types      as A
 import           Data.Char             (toUpper)
 import qualified Data.HashMap.Strict   as M
+import           Data.Scientific       (Scientific)
 import qualified Data.Text             as T
 import           Data.Time
 import           Data.Time.Clock.POSIX
@@ -283,7 +284,7 @@ instance A.FromJSON TableDescription where
         TableDescription <$> t .: "TableName"
                          <*> t .: "TableSizeBytes"
                          <*> t .: "TableStatus"
-                         <*> (fmap (posixSecondsToUTCTime . fromInteger) <$> t .:? "CreationDateTime")
+                         <*> (fmap (posixSecondsToUTCTime . fromInteger . (round :: Scientific -> Integer)) <$> t .:? "CreationDateTime")
                          <*> t .: "ItemCount"
                          <*> t .:? "AttributeDefinitions" .!= []
                          <*> t .:? "KeySchema"


### PR DESCRIPTION
It appears that sometimes aws returns CreationDateTime in floating
point unix epox format (or this was a regression, but I found no
evidence for this in the git blame).

When running tests recently I got the following error:

```
JsonProtocolError (Object (fromList [("TableDescription",Object (fromList [("TableSizeBytes",Number 0.0),("AttributeDefinitions",Array [Object (fromList [("AttributeType",String "S"),("AttributeName",String "_k")]),Object (fromList [("AttributeType",String "N"),("AttributeName",String "_t")])]),("ProvisionedThroughput",Object (fromList [("ReadCapacityUnits",Number 10.0),("WriteCapacityUnits",Number 10.0),("NumberOfDecreasesToday",Number 0.0)])),("TableStatus",String "CREATING"),("TableArn",String "xxxxxxxxxxxxxxx"),("KeySchema",Array [Object (fromList [("KeyType",String "HASH"),("AttributeName",String "_k")]),Object (fromList [("KeyType",String "RANGE"),("AttributeName",String "_t")])]),("CreationDateTime",Number 1.486669270281e9),("TableId",String "xxxxxxxxxxxxxxxxxxxx"),("ItemCount",Number 0.0),("TableName",String "xxxxxxxxxxx")]))])) "Floating number specified for Integer: 1.486669270281e9"
````

Because we're using posix second conversions anyways, it seems
perfectly fine to round (or truncate, floor, ceil, whatever) the
floating point to the latest integer before conversion. This
immediately resolved the problem for me.