### PR TITLE
Allow conduit-extra 1.2

### DIFF
--- a/aws.cabal
+++ b/aws.cabal
@@ -124,7 +124,7 @@ Library
                        case-insensitive     >= 0.2     && < 1.3,
                        cereal               >= 0.3     && < 0.6,
                        conduit              >= 1.1     && < 1.3,
-                       conduit-extra        >= 1.1     && < 1.2,
+                       conduit-extra        >= 1.1     && < 1.3,
                        containers           >= 0.4,
                        cryptohash           >= 0.11    && < 0.12,
                        data-default         >= 0.5.3   && < 0.8,


### PR DESCRIPTION
There is no breaking change for aws.