### PR TITLE
Support Signature V4 for S3

### DIFF
--- a/Aws/Aws.hs
+++ b/Aws/Aws.hs
@@ -242,6 +242,7 @@ unsafeAwsRef cfg info manager metadataRef request = do
   logDebug $ "Host: " ++ show (HTTP.host httpRequest)
   logDebug $ "Path: " ++ show (HTTP.path httpRequest)
   logDebug $ "Query string: " ++ show (HTTP.queryString httpRequest)
+  logDebug $ "Header: " ++ show (HTTP.requestHeaders httpRequest)
   case HTTP.requestBody httpRequest of
     HTTP.RequestBodyLBS lbs -> logDebug $ "Body: " ++ show (L.take 1000 lbs)
     HTTP.RequestBodyBS bs -> logDebug $ "Body: " ++ show (B.take 1000 bs)

--- a/Aws/Core.hs
+++ b/Aws/Core.hs
@@ -825,7 +825,7 @@ parseHttpDate s =     p "%a, %d %b %Y %H:%M:%S GMT" s -- rfc1123-date
                   <|> p "%a %b %_d %H:%M:%S %Y" s     -- asctime-date
                   <|> p "%Y-%m-%dT%H:%M:%S%QZ" s      -- iso 8601
                   <|> p "%Y-%m-%dT%H:%M:%S%Q%Z" s     -- iso 8601
-  where p = parseTime defaultTimeLocale
+  where p = parseTimeM True defaultTimeLocale
 
 -- | HTTP-date (section 3.3.1 of RFC 2616, first type - RFC1123-style)
 httpDate1 :: String

--- a/Aws/Core.hs
+++ b/Aws/Core.hs
@@ -52,7 +52,10 @@ module Aws.Core
 , AuthorizationHash(..)
 , amzHash
 , signature
+, credentialV4
 , authorizationV4
+, authorizationV4'
+, signatureV4
   -- ** Query construction helpers
 , queryList
 , awsBool
@@ -608,6 +611,26 @@ signature cr ah input = Base64.encode sig
               HmacSHA1 -> ByteArray.convert (CMH.hmac (secretAccessKey cr) input :: CMH.HMAC CH.SHA1)
               HmacSHA256 -> ByteArray.convert (CMH.hmac (secretAccessKey cr) input :: CMH.HMAC CH.SHA256)
 
+
+-- | Generates the Credential string, required for V4 signatures.
+credentialV4
+    :: SignatureData
+    -> B.ByteString -- ^ region, e.g. us-east-1
+    -> B.ByteString -- ^ service, e.g. dynamodb
+    -> B.ByteString
+credentialV4 sd region service = B.concat
+    [ accessKeyID (signatureCredentials sd)
+    , "/"
+    , date
+    , "/"
+    , region
+    , "/"
+    , service
+    , "/aws4_request"
+    ]
+    where
+        date = fmtTime "%Y%m%d" $ signatureTime sd
+
 -- | Use this to create the Authorization header to set into 'sqAuthorization'.
 -- See <http://docs.aws.amazon.com/general/latest/gr/signature-version-4.html>: you must create the
 -- canonical request as explained by Step 1 and this function takes care of Steps 2 and 3.
@@ -670,19 +693,81 @@ authorizationV4 sd ah region service headers canonicalRequest = do
     -- finally, return the header
     return $ B.concat [ alg
                       , " Credential="
-                      , accessKeyID (signatureCredentials sd)
-                      , "/"
-                      , date
-                      , "/"
-                      , region
-                      , "/"
-                      , service
-                      , "/aws4_request,"
-                      , "SignedHeaders="
+                      , credentialV4 sd region service
+                      , ",SignedHeaders="
                       , headers
                       , ",Signature="
                       , sig
                       ]
+
+-- | Compute the signature for V4
+signatureV4
+    :: SignatureData
+    -> AuthorizationHash
+    -> B.ByteString -- ^ region, e.g. us-east-1
+    -> B.ByteString -- ^ service, e.g. dynamodb
+    -> B.ByteString -- ^ canonicalRequest (before hashing)
+    -> B.ByteString
+signatureV4 sd ah region service canonicalRequest = Base16.encode $ mkHmac key stringToSign
+    where
+        date = fmtTime "%Y%m%d" $ signatureTime sd
+        mkHmac k i = case ah of
+            HmacSHA1 -> ByteArray.convert (CMH.hmac k i :: CMH.HMAC CH.SHA1)
+            HmacSHA256 -> ByteArray.convert (CMH.hmac k i :: CMH.HMAC CH.SHA256)
+        mkHash i = case ah of
+            HmacSHA1 -> ByteArray.convert (CH.hash i :: CH.Digest CH.SHA1)
+            HmacSHA256 -> ByteArray.convert (CH.hash i :: CH.Digest CH.SHA256)
+        alg = case ah of
+            HmacSHA1 -> "AWS4-HMAC-SHA1"
+            HmacSHA256 -> "AWS4-HMAC-SHA256"
+
+        -- create a new signing key
+        key = let secretKey = secretAccessKey $ signatureCredentials sd
+                  kDate = mkHmac ("AWS4" <> secretKey) date
+                  kRegion = mkHmac kDate region
+                  kService = mkHmac kRegion service
+                  kSigning = mkHmac kService "aws4_request"
+               in kSigning
+
+        -- now do the signature
+        canonicalRequestHash = Base16.encode $ mkHash canonicalRequest
+        stringToSign = B.concat
+            [ alg
+            , "\n"
+            , fmtTime "%Y%m%dT%H%M%SZ" $ signatureTime sd
+            , "\n"
+            , date
+            , "/"
+            , region
+            , "/"
+            , service
+            , "/aws4_request\n"
+            , canonicalRequestHash
+            ]
+
+-- | IO free version of @authorizationV4@, us this if you need
+-- to compute the signature outside of IO.
+authorizationV4'
+    :: SignatureData
+    -> AuthorizationHash
+    -> B.ByteString -- ^ region, e.g. us-east-1
+    -> B.ByteString -- ^ service, e.g. dynamodb
+    -> B.ByteString -- ^ SignedHeaders, e.g. content-type;host;x-amz-date;x-amz-target
+    -> B.ByteString -- ^ canonicalRequest (before hashing)
+    -> B.ByteString
+authorizationV4' sd ah region service headers canonicalRequest = B.concat
+    [ alg
+    , " Credential="
+    , credentialV4 sd region service
+    , ",SignedHeaders="
+    , headers
+    , ",Signature="
+    , signatureV4 sd ah region service canonicalRequest
+    ]
+    where
+        alg = case ah of
+            HmacSHA1 -> "AWS4-HMAC-SHA1"
+            HmacSHA256 -> "AWS4-HMAC-SHA256"
 
 -- | Default configuration for a specific service.
 class DefaultServiceConfiguration config where

--- a/Aws/Core.hs
+++ b/Aws/Core.hs
@@ -452,22 +452,14 @@ data SignedQuery
         -- | Additional non-"amz" headers.
       , sqOtherHeaders :: !HTTP.RequestHeaders
         -- | Request body (used with 'Post' and 'Put').
-#if MIN_VERSION_http_conduit(2, 0, 0)
       , sqBody :: !(Maybe HTTP.RequestBody)
-#else
-      , sqBody :: !(Maybe (HTTP.RequestBody (C.ResourceT IO)))
-#endif
         -- | String to sign. Note that the string is already signed, this is passed mostly for debugging purposes.
       , sqStringToSign :: !B.ByteString
       }
     --deriving (Show)
 
 -- | Create a HTTP request from a 'SignedQuery' object.
-#if MIN_VERSION_http_conduit(2, 0, 0)
 queryToHttpRequest :: SignedQuery -> IO HTTP.Request
-#else
-queryToHttpRequest :: SignedQuery -> IO (HTTP.Request (C.ResourceT IO))
-#endif
 queryToHttpRequest SignedQuery{..} =  do
     mauth <- maybe (return Nothing) (Just<$>) sqAuthorization
     return $ HTTP.defaultRequest {

--- a/Aws/Iam/Core.hs
+++ b/Aws/Iam/Core.hs
@@ -162,7 +162,7 @@ iamResponseConsumer inner md resp = xmlCursorConsumer parse md resp
 -- | Parses IAM @DateTime@ data type.
 parseDateTime :: MonadThrow m => String -> m UTCTime
 parseDateTime x
-    = case parseTime defaultTimeLocale iso8601UtcDate x of
+    = case parseTimeM True defaultTimeLocale iso8601UtcDate x of
         Nothing -> throwM $ XmlException $ "Invalid DateTime: " ++ x
         Just dt -> return dt
 

--- a/Aws/Network.hs
+++ b/Aws/Network.hs
@@ -15,6 +15,6 @@ hostAvailable h = do
     remote@(SockAddrInet _ _) -> do
       v <- catch (timeout 100000 (connect sock remote) >>= return . isJust)
                  (\(_ :: SomeException) -> return False)
-      sClose sock
+      close sock
       return v
     _ -> return False

--- a/Aws/S3/Commands/CopyObject.hs
+++ b/Aws/S3/Commands/CopyObject.hs
@@ -98,7 +98,7 @@ instance ResponseConsumer CopyObject CopyObjectResponse where
         (lastMod, etag) <- xmlCursorConsumer parse mref resp
         return $ CopyObjectResponse vid lastMod etag
       where parse el = do
-              let parseHttpDate' x = case parseTime defaultTimeLocale iso8601UtcDate x of
+              let parseHttpDate' x = case parseTimeM True defaultTimeLocale iso8601UtcDate x of
                                        Nothing -> throwM $ XmlException ("Invalid Last-Modified " ++ x)
                                        Just y -> return y
               lastMod <- forceM "Missing Last-Modified" $ el $/ elContent "LastModified" &| (parseHttpDate' . T.unpack)

--- a/Aws/S3/Commands/DeleteObject.hs
+++ b/Aws/S3/Commands/DeleteObject.hs
@@ -10,10 +10,10 @@ import qualified Data.Text.Encoding         as T
 data DeleteObject = DeleteObject {
   doObjectName :: T.Text,
   doBucket :: Bucket
-}
+} deriving (Show)
 
 data DeleteObjectResponse = DeleteObjectResponse{
-}
+} deriving (Show)
 
 -- | ServiceConfiguration: 'S3Configuration'
 instance SignQuery DeleteObject where

--- a/Aws/S3/Commands/DeleteObjectVersion.hs
+++ b/Aws/S3/Commands/DeleteObjectVersion.hs
@@ -11,7 +11,7 @@ data DeleteObjectVersion = DeleteObjectVersion {
   dovObjectName :: T.Text,
   dovBucket :: Bucket,
   dovVersionId :: T.Text
-}
+} deriving (Show)
 
 deleteObjectVersion :: Bucket -> T.Text -> T.Text -> DeleteObjectVersion
 deleteObjectVersion bucket object version
@@ -22,7 +22,7 @@ deleteObjectVersion bucket object version
         }
 
 data DeleteObjectVersionResponse = DeleteObjectVersionResponse {
-}
+} deriving (Show)
 
 -- | ServiceConfiguration: 'S3Configuration'
 instance SignQuery DeleteObjectVersion where

--- a/Aws/S3/Commands/GetService.hs
+++ b/Aws/S3/Commands/GetService.hs
@@ -35,7 +35,7 @@ instance ResponseConsumer r GetServiceResponse where
           parseBucket el = do
             name <- force "Missing owner Name" $ el $/ elContent "Name"
             creationDateString <- force "Missing owner CreationDate" $ el $/ elContent "CreationDate" &| T.unpack
-            creationDate <- force "Invalid CreationDate" . maybeToList $ parseTime defaultTimeLocale iso8601UtcDate creationDateString
+            creationDate <- force "Invalid CreationDate" . maybeToList $ parseTimeM True defaultTimeLocale iso8601UtcDate creationDateString
             return BucketInfo { bucketName = name, bucketCreationDate = creationDate }
 
 -- | ServiceConfiguration: 'S3Configuration'

--- a/Aws/S3/Commands/GetService.hs
+++ b/Aws/S3/Commands/GetService.hs
@@ -13,7 +13,7 @@ import           Text.XML.Cursor  (($/), ($//), (&|))
 import qualified Data.Text        as T
 import qualified Text.XML.Cursor  as Cu
 
-data GetService = GetService
+data GetService = GetService deriving (Show)
 
 data GetServiceResponse
     = GetServiceResponse {

--- a/Aws/S3/Commands/HeadObject.hs
+++ b/Aws/S3/Commands/HeadObject.hs
@@ -31,7 +31,7 @@ headObject b o = HeadObject b o Nothing Nothing Nothing
 data HeadObjectResponse
     = HeadObjectResponse {
         horMetadata :: Maybe ObjectMetadata
-      }
+      } deriving (Show)
 
 data HeadObjectMemoryResponse
     = HeadObjectMemoryResponse (Maybe ObjectMetadata)

--- a/Aws/S3/Commands/Multipart.hs
+++ b/Aws/S3/Commands/Multipart.hs
@@ -209,7 +209,7 @@ data CompleteMultipartUploadResponse
     , cmurKey      :: !T.Text
     , cmurETag     :: !T.Text
     , cmurVersionId :: !(Maybe T.Text)
-    }
+    } deriving (Show)
 
 -- | ServiceConfiguration: 'S3Configuration'
 instance SignQuery CompleteMultipartUpload where
@@ -296,7 +296,7 @@ postAbortMultipartUpload b o i = AbortMultipartUpload b o i
 
 data AbortMultipartUploadResponse
   = AbortMultipartUploadResponse {
-    }
+    } deriving (Show)
 
 -- | ServiceConfiguration: 'S3Configuration'
 instance SignQuery AbortMultipartUpload where

--- a/Aws/S3/Commands/PutObject.hs
+++ b/Aws/S3/Commands/PutObject.hs
@@ -29,21 +29,13 @@ data PutObject = PutObject {
   poStorageClass :: Maybe StorageClass,
   poWebsiteRedirectLocation :: Maybe T.Text,
   poServerSideEncryption :: Maybe ServerSideEncryption,
-#if MIN_VERSION_http_conduit(2, 0, 0)
   poRequestBody  :: HTTP.RequestBody,
-#else
-  poRequestBody  :: HTTP.RequestBody (C.ResourceT IO),
-#endif
   poMetadata :: [(T.Text,T.Text)],
   poAutoMakeBucket :: Bool, -- ^ Internet Archive S3 nonstandard extension
   poExpect100Continue :: Bool -- ^ Note: Requires http-client >= 0.4.10
 }
 
-#if MIN_VERSION_http_conduit(2, 0, 0)
 putObject :: Bucket -> T.Text -> HTTP.RequestBody -> PutObject
-#else
-putObject :: Bucket -> T.Text -> HTTP.RequestBody (C.ResourceT IO) -> PutObject
-#endif
 putObject bucket obj body = PutObject obj bucket Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing Nothing body [] False False
 
 data PutObjectResponse

--- a/Aws/S3/Core.hs
+++ b/Aws/S3/Core.hs
@@ -346,7 +346,7 @@ s3SignQuery S3Query{..} S3Configuration{ s3SignVersion = S3SignV4 signpayload, .
                     [ (hAmzAlgorithm, "AWS4-HMAC-SHA256")
                     , (hAmzCredential, cred)
                     , (hAmzDate, amzHeaders Map.! hAmzDate)
-                    , (hAmzExpires, B8.pack . show . floor $ diffUTCTime time signatureTime)
+                    , (hAmzExpires, B8.pack . (show :: Integer -> String) . floor $ diffUTCTime time signatureTime)
                     , (hAmzSignedHeaders, signedHeaders)
                     ] ++ iamTok
                 )
@@ -623,8 +623,8 @@ parseObjectVersionInfo el
     = do key <- force "Missing object Key" $ el $/ elContent "Key"
          versionId <- force "Missing object VersionId" $ el $/ elContent "VersionId"
          isLatest <- forceM "Missing object IsLatest" $ el $/ elContent "IsLatest" &| textReadBool
-         let time s = case (parseTime defaultTimeLocale "%Y-%m-%dT%H:%M:%S%QZ" $ T.unpack s) <|>
-                           (parseTime defaultTimeLocale "%Y-%m-%dT%H:%M:%S%Q%Z" $ T.unpack s) of
+         let time s = case (parseTimeM True defaultTimeLocale "%Y-%m-%dT%H:%M:%S%QZ" $ T.unpack s) <|>
+                           (parseTimeM True defaultTimeLocale "%Y-%m-%dT%H:%M:%S%Q%Z" $ T.unpack s) of
                         Nothing -> throwM $ XmlException "Invalid time"
                         Just v -> return v
          lastModified <- forceM "Missing object LastModified" $ el $/ elContent "LastModified" &| time
@@ -674,8 +674,8 @@ data ObjectInfo
 parseObjectInfo :: MonadThrow m => Cu.Cursor -> m ObjectInfo
 parseObjectInfo el
     = do key <- force "Missing object Key" $ el $/ elContent "Key"
-         let time s = case (parseTime defaultTimeLocale "%Y-%m-%dT%H:%M:%S%QZ" $ T.unpack s) <|>
-                           (parseTime defaultTimeLocale "%Y-%m-%dT%H:%M:%S%Q%Z" $ T.unpack s) of
+         let time s = case (parseTimeM True defaultTimeLocale "%Y-%m-%dT%H:%M:%S%QZ" $ T.unpack s) <|>
+                           (parseTimeM True defaultTimeLocale "%Y-%m-%dT%H:%M:%S%Q%Z" $ T.unpack s) of
                         Nothing -> throwM $ XmlException "Invalid time"
                         Just v -> return v
          lastModified <- forceM "Missing object LastModified" $ el $/ elContent "LastModified" &| time

--- a/Aws/S3/Core.hs
+++ b/Aws/S3/Core.hs
@@ -340,7 +340,7 @@ s3SignQuery S3Query{..} S3Configuration{ s3SignVersion = S3SignV4 signpayload, .
             ]
 
         (authorization, signatureQuery, queryString) = case ti of
-            AbsoluteTimestamp _  -> (Just . return $ auth, [], allQueries)
+            AbsoluteTimestamp _  -> (Just auth, [], allQueries)
             AbsoluteExpires time ->
                 ( Nothing
                 , [(CI.original hAmzSignature, Just sig)]
@@ -355,9 +355,9 @@ s3SignQuery S3Query{..} S3Configuration{ s3SignVersion = S3SignV4 signpayload, .
             where
                 allQueries = s3QSubresources ++ s3QQuery
                 region = s3ExtractRegion s3Endpoint
-                auth = authorizationV4' sd HmacSHA256 region "s3" signedHeaders stringToSign
-                sig  = signatureV4      sd HmacSHA256 region "s3"               stringToSign
-                cred = credentialV4     sd            region "s3"
+                auth = authorizationV4 sd HmacSHA256 region "s3" signedHeaders stringToSign
+                sig  = signatureV4     sd HmacSHA256 region "s3"               stringToSign
+                cred = credentialV4    sd            region "s3"
                 ti = case (s3UseUri, signatureTimeInfo) of
                     (False, t) -> t
                     (True, AbsoluteTimestamp time) -> AbsoluteExpires $ s3DefaultExpiry `addUTCTime` time

--- a/Aws/S3/Core.hs
+++ b/Aws/S3/Core.hs
@@ -176,11 +176,7 @@ data S3Query
       , s3QContentMd5 :: Maybe (CH.Digest CH.MD5)
       , s3QAmzHeaders :: HTTP.RequestHeaders
       , s3QOtherHeaders :: HTTP.RequestHeaders
-#if MIN_VERSION_http_conduit(2, 0, 0)
       , s3QRequestBody :: Maybe HTTP.RequestBody
-#else
-      , s3QRequestBody :: Maybe (HTTP.RequestBody (C.ResourceT IO))
-#endif
       }
 
 instance Show S3Query where

--- a/Examples/GetObjectGoogle.hs
+++ b/Examples/GetObjectGoogle.hs
@@ -10,7 +10,7 @@ import           Network.HTTP.Conduit (withManager, responseBody)
 main :: IO ()
 main = do
   Just creds <- Aws.loadCredentialsFromEnv
-  let cfg = Aws.Configuration Aws.Timestamp creds (Aws.defaultLog Aws.Debug)
+  let cfg = Aws.Configuration Aws.Timestamp creds (Aws.defaultLog Aws.Debug) Nothing
   let s3cfg = S3.s3 Aws.HTTP "storage.googleapis.com" False
   {- Set up a ResourceT region with an available HTTP manager. -}
   withManager $ \mgr -> do

--- a/Examples/GetObjectV4.hs
+++ b/Examples/GetObjectV4.hs
@@ -1,0 +1,27 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+import qualified Aws
+import qualified Aws.Core as Aws
+import qualified Aws.S3 as S3
+import           Control.Monad.Trans.Resource
+import           Data.Conduit (($$+-))
+import           Data.Conduit.Binary (sinkFile)
+import           Network.HTTP.Conduit (newManager, tlsManagerSettings, responseBody)
+
+main :: IO ()
+main = do
+  {- Set up AWS credentials and the default configuration. -}
+  Just creds <- Aws.loadCredentialsDefault
+  let cfg = Aws.Configuration Aws.Timestamp creds (Aws.defaultLog Aws.Debug) Nothing
+  let s3cfg = S3.s3v4 Aws.HTTP "s3.amazonaws.com" False S3.SignWithEffort
+
+  {- Set up a ResourceT region with an available HTTP manager. -}
+  mgr <- newManager tlsManagerSettings
+  runResourceT $ do
+    {- Create a request object with S3.getObject and run the request with pureAws. -}
+    S3.GetObjectResponse { S3.gorResponse = rsp } <-
+      Aws.pureAws cfg s3cfg mgr $
+        S3.getObject "haskell-aws" "cloud-remote.pdf"
+
+    {- Save the response to a file. -}
+    responseBody rsp $$+- sinkFile "cloud-remote.pdf"

--- a/Examples/MultipartUpload.hs
+++ b/Examples/MultipartUpload.hs
@@ -1,30 +1,30 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 import qualified Aws
+import qualified Aws.Core as Aws
 import qualified Aws.S3 as S3
+import qualified Data.ByteString.Char8 as B
 import           Data.Conduit (($$))
 import           Data.Conduit.Binary (sourceFile)
 import qualified Data.Text as T
-import           Network.HTTP.Conduit (withManager, responseBody)
-import           Control.Monad.Trans.Resource (ResourceT)
+import           Network.HTTP.Conduit (newManager, tlsManagerSettings, responseBody)
+import           Control.Monad.Trans.Resource (runResourceT)
 import           System.Environment (getArgs)
 
 main :: IO ()
 main = do
-  {- Set up AWS credentials and the default configuration. -}
-  cfg <- Aws.dbgConfiguration
-  let s3cfg = Aws.defServiceConfig :: S3.S3Configuration Aws.NormalQuery
-
   args <- getArgs
-
-  let doUpload bucket obj file chunkSize =
-        withManager $ \mgr -> do
-          (sourceFile file $$ S3.multipartUploadSink cfg s3cfg mgr (T.pack bucket) (T.pack obj) (chunkSize*1024*1024)) :: ResourceT IO ()
-
   case args of
-    [bucket,obj,file] ->
-      doUpload bucket obj file 10
-    [bucket,obj,file,chunkSize] ->
-      doUpload bucket obj file (read chunkSize)
-    _ -> do
-      putStrLn "Usage: MultipartUpload bucket objectname filename (chunksize(MB)::optinal)"
+    [endpoint, bucket, obj, file]            -> doUpload endpoint bucket obj file 10
+    [endpoint, bucket, obj, file, chunkSize] -> doUpload endpoint bucket obj file (read chunkSize)
+    _ -> mapM_ putStrLn
+      [ "Usage: MultipartUpload endpoint bucket dstobject srcfile [chunksize(MB)]"
+      , "Example: MultipartUpload s3.us-east-2.amazonaws.com your-bucket tmp/test.bin test.bin"
+      ]
+  where
+    doUpload endpoint bucket obj file chunkSize = do
+      cfg <- Aws.dbgConfiguration
+      let s3cfg = S3.s3v4 Aws.HTTPS (B.pack endpoint) False S3.SignWithEffort
+      mgr <- newManager tlsManagerSettings
+      runResourceT $
+        sourceFile file $$ S3.multipartUploadSink cfg s3cfg mgr (T.pack bucket) (T.pack obj) (chunkSize*1024*1024)

--- a/Examples/PutBucketNearLine.hs
+++ b/Examples/PutBucketNearLine.hs
@@ -25,7 +25,7 @@ main = do
   {- Set up AWS credentials and S3 configuration using the Google Cloud
    - Storage endpoint. -}
   Just creds <- Aws.loadCredentialsFromEnv
-  let cfg = Aws.Configuration Aws.Timestamp creds (Aws.defaultLog Aws.Debug)
+  let cfg = Aws.Configuration Aws.Timestamp creds (Aws.defaultLog Aws.Debug) Nothing
   let s3cfg = S3.s3 Aws.HTTP "storage.googleapis.com" False
 
   {- Set up a ResourceT region with an available HTTP manager. -}

--- a/aws.cabal
+++ b/aws.cabal
@@ -171,6 +171,24 @@ Library
         EmptyDataDecls,
         Rank2Types
 
+Executable GetObjectV4
+  Main-is: GetObjectV4.hs
+  Hs-source-dirs: Examples
+
+  if !flag(Examples)
+    Buildable: False
+  else
+    Buildable: True
+    Build-depends:
+                       base == 4.*,
+                       aws,
+                       http-conduit,
+                       conduit,
+                       conduit-extra,
+                       resourcet
+
+  Default-Language: Haskell2010
+
 Executable GetObject
   Main-is: GetObject.hs
   Hs-source-dirs: Examples

--- a/aws.cabal
+++ b/aws.cabal
@@ -234,6 +234,7 @@ Executable MultipartUpload
     Build-depends:
                        base == 4.*,
                        aws,
+                       bytestring,
                        http-conduit,
                        conduit,
                        conduit-extra,


### PR DESCRIPTION
This PR supports Signature Version 4 for S3.
Some examples use V4 now.

It should replace #199.
Some codes have been copied from #199, my thanks to @angerman .