### PR TITLE
Add eu-west-2 endpoint for specific services

### DIFF
--- a/Aws/DynamoDb/Core.hs
+++ b/Aws/DynamoDb/Core.hs
@@ -31,6 +31,7 @@ module Aws.DynamoDb.Core
     , ddbUsWest1
     , ddbUsWest2
     , ddbEuWest1
+    , ddbEuWest2
     , ddbEuCentral1
     , ddbApNe1
     , ddbApSe1
@@ -792,6 +793,9 @@ ddbUsWest2 = Region "dynamodb.us-west-2.amazonaws.com" "us-west-2"
 
 ddbEuWest1 :: Region
 ddbEuWest1 = Region "dynamodb.eu-west-1.amazonaws.com" "eu-west-1"
+
+ddbEuWest2 :: Region
+ddbEuWest2 = Region "dynamodb.eu-west-2.amazonaws.com" "eu-west-2"
 
 ddbEuCentral1 :: Region
 ddbEuCentral1 = Region "dynamodb.eu-central-1.amazonaws.com" "eu-central-1"

--- a/Aws/S3/Core.hs
+++ b/Aws/S3/Core.hs
@@ -99,6 +99,9 @@ s3EndpointUsWest2 = "s3-us-west-2.amazonaws.com"
 s3EndpointEu :: B.ByteString
 s3EndpointEu = "s3-eu-west-1.amazonaws.com"
 
+s3EndpointEuWest2 :: B.ByteString
+s3EndpointEuWest2 = "s3-eu-west-2.amazonaws.com"
+
 s3EndpointApSouthEast :: B.ByteString
 s3EndpointApSouthEast = "s3-ap-southeast-1.amazonaws.com"
 
@@ -707,11 +710,12 @@ parseObjectMetadata h = ObjectMetadata
 
 type LocationConstraint = T.Text
 
-locationUsClassic, locationUsWest, locationUsWest2, locationEu, locationEuFrankfurt, locationApSouthEast, locationApSouthEast2, locationApNorthEast, locationSA :: LocationConstraint
+locationUsClassic, locationUsWest, locationUsWest2, locationEu, locationEuWest2, locationEuFrankfurt, locationApSouthEast, locationApSouthEast2, locationApNorthEast, locationSA :: LocationConstraint
 locationUsClassic = ""
 locationUsWest = "us-west-1"
 locationUsWest2 = "us-west-2"
 locationEu = "EU"
+locationEuWest2 = "eu-west-2"
 locationEuFrankfurt = "eu-central-1"
 locationApSouthEast = "ap-southeast-1"
 locationApSouthEast2 = "ap-southeast-2"

--- a/Aws/Sqs/Core.hs
+++ b/Aws/Sqs/Core.hs
@@ -2,7 +2,7 @@
 module Aws.Sqs.Core where
 
 import           Aws.Core
-import           Aws.S3.Core                    (LocationConstraint, locationUsClassic, locationUsWest, locationUsWest2, locationApSouthEast, locationApSouthEast2, locationApNorthEast, locationEu)
+import           Aws.S3.Core                    (LocationConstraint, locationUsClassic, locationUsWest, locationUsWest2, locationApSouthEast, locationApSouthEast2, locationApNorthEast, locationEu, locationEuWest2)
 import qualified Blaze.ByteString.Builder       as Blaze
 import qualified Blaze.ByteString.Builder.Char8 as Blaze8
 import qualified Control.Exception              as C
@@ -133,6 +133,14 @@ sqsEndpointEu
         endpointHost = "eu-west-1.queue.amazonaws.com"
       , endpointDefaultLocationConstraint = locationEu
       , endpointAllowedLocationConstraints = [locationEu]
+      }
+
+sqsEndpointEuWest2 :: Endpoint
+sqsEndpointEuWest2
+    = Endpoint {
+        endpointHost = "eu-west-2.queue.amazonaws.com"
+      , endpointDefaultLocationConstraint = locationEuWest2
+      , endpointAllowedLocationConstraints = [locationEuWest2]
       }
 
 sqsEndpointApSouthEast :: Endpoint


### PR DESCRIPTION
This PR adds the London region to a few services:

* DynamoDB region added and tested using one of the example scripts.
* S3 region added and tested using one of the example scripts.
* SQS region added but not tested. The example did not work for me, but this is most likely due to my account.

The remaining services were left unchanged:

* SES does not support EU west 2 (yet?).
* IAM is a global service, so it does not support regions as far as I know.
* The EC2 implementation doesn't have regions listed at the moment.
* SimpleDB was not available in my account, so I could not try it out.

Could someone test the SQS region for me?