### PR TITLE
Fix V2 path when calculating signature

### DIFF
--- a/Aws/S3/Core.hs
+++ b/Aws/S3/Core.hs
@@ -231,7 +231,7 @@ s3SignQuery S3Query{..} S3Configuration{ s3SignVersion = S3SignV2, .. } Signatur
                                                  | otherwise = x1 : merge (x2 : xs)
                 merge xs = xs
 
-      urlEncodedS3QObject = HTTP.urlEncode False <$> s3QObject
+      urlEncodedS3QObject = s3UriEncode False <$> s3QObject
       (host, path) = case s3RequestStyle of
                        PathStyle   -> ([Just s3Endpoint], [Just "/", fmap (`B8.snoc` '/') s3QBucket, urlEncodedS3QObject])
                        BucketStyle -> ([s3QBucket, Just s3Endpoint], [Just "/", urlEncodedS3QObject])


### PR DESCRIPTION
Similarly to how it is done for V4 [here](https://github.com/aristidb/aws/blob/master/Aws/S3/Core.hs#L322), we should not touch forward slashes when creating the string to sign as described in the [docs](https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html)

_Encode the forward slash character, '/', everywhere except in the object key name. For example, if the object key name is photos/Jan/sample.jpg, the forward slash in the key name is not encoded._