### PR TITLE
DisplayName should be optional

### DIFF
--- a/Aws/S3/Core.hs
+++ b/Aws/S3/Core.hs
@@ -483,13 +483,15 @@ type CanonicalUserId = T.Text
 data UserInfo
     = UserInfo {
         userId          :: CanonicalUserId
-      , userDisplayName :: T.Text
+      , userDisplayName :: Maybe T.Text
       }
     deriving (Show)
 
 parseUserInfo :: MonadThrow m => Cu.Cursor -> m UserInfo
 parseUserInfo el = do id_ <- force "Missing user ID" $ el $/ elContent "ID"
-                      displayName <- force "Missing user DisplayName" $ el $/ elContent "DisplayName"
+                      displayName <- return $ case (el $/ elContent "DisplayName") of
+                                                  (x:_) -> Just x
+                                                  []    -> Nothing
                       return UserInfo { userId = id_, userDisplayName = displayName }
 
 data CannedAcl


### PR DESCRIPTION
There are cases where the `DisplayName` is an empty string, which causes the `UserInfo` parser to fail since it requires that the `DisplayName` to be a non-empty string (note that the key itself is present)