### PR TITLE
Use http-client-tls global manager for http request by default.

### DIFF
--- a/Aws/Aws.hs
+++ b/Aws/Aws.hs
@@ -51,6 +51,7 @@ import qualified Data.Text                    as T
 import qualified Data.Text.Encoding           as T
 import qualified Data.Text.IO                 as T
 import qualified Network.HTTP.Conduit         as HTTP
+import qualified Network.HTTP.Client.TLS      as HTTP
 import           System.IO                    (stderr)
 import           Prelude
 
@@ -193,7 +194,7 @@ simpleAws :: (Transaction r a, AsMemoryResponse a, MonadIO io)
             -> r
             -> io (MemoryResponse a)
 simpleAws cfg scfg request = liftIO $ runResourceT $ do
-    manager <- liftIO $ HTTP.newManager HTTP.tlsManagerSettings
+    manager <- liftIO HTTP.getGlobalManager
     loadToMemory =<< readResponseIO =<< aws cfg scfg manager request
 
 -- | Run an AWS transaction, without enforcing that response and request type form a valid transaction pair.

--- a/Aws/Core.hs
+++ b/Aws/Core.hs
@@ -134,6 +134,7 @@ import qualified Data.Traversable         as Traversable
 import           Data.Typeable
 import           Data.Word
 import qualified Network.HTTP.Conduit     as HTTP
+import qualified Network.HTTP.Client.TLS  as HTTP
 import qualified Network.HTTP.Types       as HTTP
 import           System.Directory
 import           System.Environment
@@ -326,7 +327,7 @@ loadCredentialsFromEnv = liftIO $ do
 
 loadCredentialsFromInstanceMetadata :: MonadIO io => io (Maybe Credentials)
 loadCredentialsFromInstanceMetadata = do
-    mgr <- liftIO $ HTTP.newManager HTTP.tlsManagerSettings
+    mgr <- liftIO HTTP.getGlobalManager
     -- check if the path is routable
     avail <- liftIO $ hostAvailable "169.254.169.254"
     if not avail

--- a/aws.cabal
+++ b/aws.cabal
@@ -131,6 +131,7 @@ Library
                        directory            >= 1.0     && < 2.0,
                        filepath             >= 1.1     && < 1.5,
                        http-conduit         >= 2.3     && < 2.4,
+                       http-client-tls      >= 0.3     && < 0.4,
                        http-types           >= 0.7     && < 1.0,
                        lifted-base          >= 0.1     && < 0.3,
                        memory,


### PR DESCRIPTION
Default to using `http-client-tls`'s global http manager by default instead of instantiating a new manager.

> Creating a new Manager is a relatively expensive operation, you are advised to share a single Manager between requests instead.

It's probably possible to avoid the `http-client-tls` import (even though it's already a transitive dep) but the change would need a few more lines. I'm not certain it's worth the effort given the current patch's simplicity.