### PR TITLE
support network-3

### DIFF
--- a/aws.cabal
+++ b/aws.cabal
@@ -29,6 +29,10 @@ Flag Examples
   Description: Build the examples.
   Default: False
 
+Flag NetworkBSD
+  Description: Build with network-3.0 which split out network-bsd
+  Default: True
+
 Library
   Exposed-modules:
                        Aws
@@ -149,7 +153,6 @@ Library
                        monad-control        >= 0.3,
                        exceptions           >= 0.8     && < 0.11,
                        mtl                  == 2.*,
-                       network              == 2.*,
                        old-locale           == 1.*,
                        resourcet            >= 1.2     && < 1.3,
                        safe                 >= 0.3     && < 0.4,
@@ -162,6 +165,10 @@ Library
                        utf8-string          >= 0.3     && < 1.1,
                        vector               >= 0.10,
                        xml-conduit          >= 1.8     && <2.0
+  if flag(NetworkBSD)
+    Build-depends: network == 3.*, network-bsd == 2.8.*
+  else
+    Build-depends: network == 2.*
  
   if !impl(ghc >= 7.6)
     Build-depends: ghc-prim


### PR DESCRIPTION
fixes https://github.com/aristidb/aws/issues/264

This keeps support for building with network-2 by adding a build flag.
Cabal will automatically disable the build flag if that's the only way
to satisfy the dependencies.

At some point in the future when network-2 compatability is not useful,
it would make sense to remove the build flag.