### PR TITLE
Allow base64-bytestring 1.2.*

### DIFF
--- a/aws.cabal
+++ b/aws.cabal
@@ -132,7 +132,7 @@ Library
                        attoparsec           >= 0.11    && < 0.14,
                        base                 >= 4.6     && < 5,
                        base16-bytestring    == 0.1.*,
-                       base64-bytestring    == 1.0.*,
+                       base64-bytestring    >= 1.0     && < 1.3,
                        blaze-builder        >= 0.2.1.4 && < 0.5,
                        byteable             == 0.1.*,
                        bytestring           >= 0.9     && < 0.11,


### PR DESCRIPTION
I have build the lib successfully with base64-bytestring 1.2.0.1 and the Changelog doesn‘t seem like this is an issue.