### PR TITLE
support S3 access without credentials, by using anonymousCredentials

### DIFF
--- a/Aws.hs
+++ b/Aws.hs
@@ -58,6 +58,7 @@ module Aws
 , loadCredentialsFromEnvOrFile
 , loadCredentialsFromEnvOrFileOrInstanceMetadata
 , loadCredentialsDefault
+, anonymousCredentials
 )
 where
 

--- a/aws.cabal
+++ b/aws.cabal
@@ -1,5 +1,5 @@
 Name:                aws
-Version:             0.22.1
+Version:             0.23
 Synopsis:            Amazon Web Services (AWS) for Haskell
 Description:         Bindings for Amazon Web Services (AWS), with the aim of supporting all AWS services. To see a high level overview of the library, see the README at <https://github.com/aristidb/aws/blob/master/README.md>.
 Homepage:            http://github.com/aristidb/aws


### PR DESCRIPTION
This allows using GetBucket and GetObject against a public S3 bucket. Other actions may also work for the rare bucket that supports unauthenticated writes.

anonymousCredentials generates a Credentials with the access key and secret key both empty. So AWS requests that do not support anonymous access will proceed the same ways that they currently do when the user sets AWS_ACCESS_KEY_ID="" and AWS_SECRET_ACCESS_KEY="". Eg, the AWS server will reject the request because it is not properly signed.

isAnonymousCredentials was added as a field of Credentials to allow differentiating between anonymousCredentials being used, and the user providing empty credentials. This avoids a behavior change when the user provides empty credentials to a program that uses S3. The new constructor means that the version needs to be bumped to eg 0.23.

Closes https://github.com/aristidb/aws/issues/279